### PR TITLE
add percentage aggregate

### DIFF
--- a/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/Count.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/Count.scala
@@ -2,18 +2,22 @@ package io.epiphanous.flinkrunner.model.aggregate
 import java.time.Instant
 
 import io.epiphanous.flinkrunner.model.UnitMapper
+import squants.Each
 
 final case class Count(
-  dimension: String = "Dimensionless",
-  unit: String = "ea",
+  dimension: String,
+  unit: String,
   value: Double = 0d,
-  name: String = "Count",
   count: BigInt = BigInt(0),
   aggregatedLastUpdated: Instant = Instant.EPOCH,
   lastUpdated: Instant = Instant.now(),
   dependentAggregations: Map[String, Aggregate] = Map.empty[String, Aggregate],
-  params: Map[String, Any] = Map.empty[String, Any])
+  params: Map[String, String] = Map.empty[String, String])
     extends Aggregate {
+
+  override def isDimensionless = true
+
+  override def outUnit: String = Each.symbol
 
   override def update(
     value: Double,
@@ -21,10 +25,5 @@ final case class Count(
     aggLU: Instant,
     unitMapper: UnitMapper = UnitMapper.defaultUnitMapper
   ) =
-    Some(copy(value = this.value + 1, count = count + 1, aggregatedLastUpdated = aggLU))
-}
-
-object Count {
-  def apply(dimension: String, unit: String): Count =
-    Count()
+    Some(copy(value = this.value + 1, unit = outUnit, count = count + 1, aggregatedLastUpdated = aggLU))
 }

--- a/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/ExponentialMovingAverage.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/ExponentialMovingAverage.scala
@@ -7,15 +7,14 @@ final case class ExponentialMovingAverage(
   dimension: String,
   unit: String,
   value: Double = 0d,
-  name: String = "ExponentialMovingAverage",
   count: BigInt = BigInt(0),
   aggregatedLastUpdated: Instant = Instant.EPOCH,
   lastUpdated: Instant = Instant.now(),
   dependentAggregations: Map[String, Aggregate] = Map.empty[String, Aggregate],
-  params: Map[String, Any] = Map("alpha" -> 0.7))
+  params: Map[String, String] = Map("alpha" -> ExponentialMovingAverage.defaultAlpha))
     extends Aggregate {
 
-  def alpha: Double = params.getOrElse("alpha", 0.7).asInstanceOf[Double]
+  def alpha: Double = params.getOrElse("alpha", ExponentialMovingAverage.defaultAlpha).toDouble
 
   override def updateQuantity[A <: Quantity[A]](current: A, quantity: A, depAggs: Map[String, Aggregate]) =
     current * (1 - alpha) + quantity * alpha
@@ -23,6 +22,8 @@ final case class ExponentialMovingAverage(
 }
 
 object ExponentialMovingAverage {
+  final val DEFAULT_ALPHA = 0.7
+  def defaultAlpha = DEFAULT_ALPHA.toString
   def apply(dimension: String, unit: String, alpha: Double): ExponentialMovingAverage =
-    ExponentialMovingAverage(dimension, unit, params = Map("alpha" -> alpha))
+    ExponentialMovingAverage(dimension, unit, params = Map("alpha" -> alpha.toString))
 }

--- a/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/ExponentialMovingStandardDeviation.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/ExponentialMovingStandardDeviation.scala
@@ -8,12 +8,11 @@ final case class ExponentialMovingStandardDeviation(
   dimension: String,
   unit: String,
   value: Double = 0d,
-  name: String = "ExponentialMovingStandardDeviation",
   count: BigInt = BigInt(0),
   aggregatedLastUpdated: Instant = Instant.EPOCH,
   lastUpdated: Instant = Instant.now(),
   dependentAggregations: Map[String, Aggregate] = Map.empty[String, Aggregate],
-  params: Map[String, Any] = Map.empty[String, Any])
+  params: Map[String, String] = Map("alpha" -> ExponentialMovingStandardDeviation.defaultAlpha))
     extends Aggregate {
 
   override def getDependents = {
@@ -30,11 +29,15 @@ final case class ExponentialMovingStandardDeviation(
 }
 
 object ExponentialMovingStandardDeviation {
+  private val DEFAULT_ALPHA = 0.7
+  def defaultAlpha = DEFAULT_ALPHA.toString
   def apply(dimension: String, unit: String, alpha: Double): ExponentialMovingStandardDeviation =
-    ExponentialMovingStandardDeviation(
-      dimension,
-      unit,
-      dependentAggregations = Map("ExponentialMovingVariance" -> ExponentialMovingVariance(dimension, unit, alpha)),
-      params = Map("alpha" -> alpha)
-    )
+    ExponentialMovingStandardDeviation(dimension,
+                                       unit,
+                                       dependentAggregations = Map(
+                                         "ExponentialMovingVariance" -> ExponentialMovingVariance(dimension,
+                                                                                                  unit,
+                                                                                                  alpha)
+                                       ),
+                                       params = Map("alpha" -> alpha.toString))
 }

--- a/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/ExponentialMovingVariance.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/ExponentialMovingVariance.scala
@@ -7,15 +7,14 @@ final case class ExponentialMovingVariance(
   dimension: String,
   unit: String,
   value: Double = 0d,
-  name: String = "ExponentialMovingVariance",
   count: BigInt = BigInt(0),
   aggregatedLastUpdated: Instant = Instant.EPOCH,
   lastUpdated: Instant = Instant.now(),
   dependentAggregations: Map[String, Aggregate] = Map.empty[String, Aggregate],
-  params: Map[String, Any] = Map("alpha" -> 0.7))
+  params: Map[String, String] = Map("alpha" -> ExponentialMovingVariance.defaultAlpha))
     extends Aggregate {
 
-  def alpha = params.getOrElse("alpha", 0.7).asInstanceOf[Double]
+  def alpha = params.getOrElse("alpha", ExponentialMovingVariance.defaultAlpha).toDouble
 
   override def getDependents = {
     if (this.dependentAggregations.isEmpty)
@@ -33,7 +32,9 @@ final case class ExponentialMovingVariance(
 }
 
 object ExponentialMovingVariance {
+  final val DEFAULT_ALPHA = 0.7
+  def defaultAlpha = DEFAULT_ALPHA.toString
   def apply(dimension: String, unit: String, alpha: Double): ExponentialMovingVariance =
-    ExponentialMovingVariance(dimension, unit, params = Map("alpha" -> alpha))
+    ExponentialMovingVariance(dimension, unit, params = Map("alpha" -> alpha.toString))
 
 }

--- a/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/Histogram.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/Histogram.scala
@@ -8,17 +8,16 @@ final case class Histogram(
   dimension: String,
   unit: String,
   value: Double = 0d,
-  name: String = "Histogram",
   count: BigInt = BigInt(0),
   aggregatedLastUpdated: Instant = Instant.EPOCH,
   lastUpdated: Instant = Instant.now(),
   dependentAggregations: Map[String, Aggregate] = Map.empty[String, Aggregate],
-  params: Map[String, Any] = Map.empty[String, Any])
+  params: Map[String, String] = Map.empty[String, String])
     extends Aggregate {
 
   import Histogram._
 
-  def bin(key: String): Aggregate = this.dependentAggregations.getOrElse(key, Count())
+  def bin(key: String): Aggregate = this.dependentAggregations.getOrElse(key, Count(dimension, unit))
 
   /** Compute a dynamic bin for the requested quantity. This picks a bin
     * based on the order of magnitude of the quantity in the aggregate's preferred unit.

--- a/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/Max.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/Max.scala
@@ -7,12 +7,11 @@ final case class Max(
   dimension: String,
   unit: String,
   value: Double = 0d,
-  name: String = "Max",
   count: BigInt = BigInt(0),
   aggregatedLastUpdated: Instant = Instant.EPOCH,
   lastUpdated: Instant = Instant.now(),
   dependentAggregations: Map[String, Aggregate] = Map.empty[String, Aggregate],
-  params: Map[String, Any] = Map.empty[String, Any])
+  params: Map[String, String] = Map.empty[String, String])
     extends Aggregate {
 
   override def updateQuantity[A <: Quantity[A]](current: A, quantity: A, depAggs: Map[String, Aggregate]) =

--- a/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/Mean.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/Mean.scala
@@ -7,12 +7,11 @@ final case class Mean(
   dimension: String,
   unit: String,
   value: Double = 0d,
-  name: String = "Mean",
   count: BigInt = BigInt(0),
   aggregatedLastUpdated: Instant = Instant.EPOCH,
   lastUpdated: Instant = Instant.now(),
   dependentAggregations: Map[String, Aggregate] = Map.empty[String, Aggregate],
-  params: Map[String, Any] = Map.empty[String, Any])
+  params: Map[String, String] = Map.empty[String, String])
     extends Aggregate {
 
   override def updateQuantity[A <: Quantity[A]](current: A, quantity: A, depAggs: Map[String, Aggregate]) = {

--- a/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/Min.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/Min.scala
@@ -7,12 +7,11 @@ final case class Min(
   dimension: String,
   unit: String,
   value: Double = Double.MaxValue,
-  name: String = "Min",
   count: BigInt = BigInt(0),
   aggregatedLastUpdated: Instant = Instant.EPOCH,
   lastUpdated: Instant = Instant.now(),
   dependentAggregations: Map[String, Aggregate] = Map.empty[String, Aggregate],
-  params: Map[String, Any] = Map.empty[String, Any])
+  params: Map[String, String] = Map.empty[String, String])
     extends Aggregate {
 
   override def updateQuantity[A <: Quantity[A]](current: A, quantity: A, depAggs: Map[String, Aggregate]) =

--- a/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/Percentage.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/Percentage.scala
@@ -1,0 +1,40 @@
+package io.epiphanous.flinkrunner.model.aggregate
+
+import java.time.Instant
+
+import io.epiphanous.flinkrunner.model.UnitMapper
+import squants.Quantity
+
+final case class Percentage(
+  dimension: String,
+  unit: String,
+  value: Double = 0d,
+  name: String = "Percentage",
+  count: BigInt = BigInt(0),
+  aggregatedLastUpdated: Instant = Instant.EPOCH,
+  lastUpdated: Instant = Instant.now(),
+  dependentAggregations: Map[String, Aggregate] = Map.empty[String, Aggregate],
+  params: Map[String, Any] = Map("base" -> 1d))
+    extends Aggregate {
+
+  val baseParam: Double = params.getOrElse("base", 1d).asInstanceOf[Double]
+
+  def baseQuantity[A <: Quantity[A]](q: A, unitMapper: UnitMapper) =
+    unitMapper.createQuantity(q.dimension, baseParam, unit)
+
+  override def update[A <: Quantity[A]](q: A, aggLU: Instant, unitMapper: UnitMapper) = {
+    val updateValue = baseQuantity(q, unitMapper).map(b => q / b) match {
+      case Some(addValue) => addValue
+      case None =>
+        logger.error(s"$name[$dimension,$unit] can not be updated with (Quantity[${q.dimension.name}]=$q)")
+        0d
+    }
+    Some(copy(value = this.value + updateValue, count = count + 1, aggregatedLastUpdated = aggLU))
+  }
+
+}
+
+object Percentage {
+  def apply(dimension: String, unit: String, base: Double): Percentage =
+    Percentage(dimension, unit, params = Map("base" -> base))
+}

--- a/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/Range.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/Range.scala
@@ -7,12 +7,11 @@ final case class Range(
   dimension: String,
   unit: String,
   value: Double = 0d,
-  name: String = "Range",
   count: BigInt = BigInt(0),
   aggregatedLastUpdated: Instant = Instant.EPOCH,
   lastUpdated: Instant = Instant.now(),
   dependentAggregations: Map[String, Aggregate] = Map.empty[String, Aggregate],
-  params: Map[String, Any] = Map.empty[String, Any])
+  params: Map[String, String] = Map.empty[String, String])
     extends Aggregate {
 
   override def getDependents = {

--- a/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/StandardDeviation.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/StandardDeviation.scala
@@ -8,12 +8,11 @@ final case class StandardDeviation(
   dimension: String,
   unit: String,
   value: Double = 0d,
-  name: String = "StandardDeviation",
   count: BigInt = BigInt(0),
   aggregatedLastUpdated: Instant = Instant.EPOCH,
   lastUpdated: Instant = Instant.now(),
   dependentAggregations: Map[String, Aggregate] = Map.empty[String, Aggregate],
-  params: Map[String, Any] = Map.empty[String, Any])
+  params: Map[String, String] = Map.empty[String, String])
     extends Aggregate {
 
   override def updateQuantity[A <: Quantity[A]](current: A, quantity: A, depAggs: Map[String, Aggregate]) = {

--- a/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/Sum.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/Sum.scala
@@ -7,12 +7,11 @@ final case class Sum(
   dimension: String,
   unit: String,
   value: Double = 0d,
-  name: String = "Sum",
   count: BigInt = BigInt(0),
   aggregatedLastUpdated: Instant = Instant.EPOCH,
   lastUpdated: Instant = Instant.now(),
   dependentAggregations: Map[String, Aggregate] = Map.empty[String, Aggregate],
-  params: Map[String, Any] = Map.empty[String, Any])
+  params: Map[String, String] = Map.empty[String, String])
     extends Aggregate {
 
   override def updateQuantity[A <: Quantity[A]](current: A, quantity: A, depAggs: Map[String, Aggregate]) =

--- a/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/SumOfSquaredDeviations.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/SumOfSquaredDeviations.scala
@@ -7,12 +7,11 @@ final case class SumOfSquaredDeviations(
   dimension: String,
   unit: String,
   value: Double = 0d,
-  name: String = "Sum",
   count: BigInt = BigInt(0),
   aggregatedLastUpdated: Instant = Instant.EPOCH,
   lastUpdated: Instant = Instant.now(),
   dependentAggregations: Map[String, Aggregate] = Map.empty[String, Aggregate],
-  params: Map[String, Any] = Map.empty[String, Any])
+  params: Map[String, String] = Map.empty[String, String])
     extends Aggregate {
 
   override def getDependents = {

--- a/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/Variance.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/Variance.scala
@@ -7,12 +7,11 @@ final case class Variance(
   dimension: String,
   unit: String,
   value: Double = 0d,
-  name: String = "Variance",
   count: BigInt = BigInt(0),
   aggregatedLastUpdated: Instant = Instant.EPOCH,
   lastUpdated: Instant = Instant.now(),
   dependentAggregations: Map[String, Aggregate] = Map.empty[String, Aggregate],
-  params: Map[String, Any] = Map.empty[String, Any])
+  params: Map[String, String] = Map.empty[String, String])
     extends Aggregate {
 
   override def getDependents = {

--- a/src/test/scala/io/epiphanous/flinkrunner/model/aggregate/PercentageTest.scala
+++ b/src/test/scala/io/epiphanous/flinkrunner/model/aggregate/PercentageTest.scala
@@ -1,0 +1,41 @@
+package io.epiphanous.flinkrunner.model.aggregate
+
+import java.time.Instant
+
+import com.typesafe.scalalogging.LazyLogging
+import org.scalatest.{FlatSpec, Matchers}
+import squants.time.{Seconds, Time}
+
+class PercentageTest extends FlatSpec with Matchers with LazyLogging {
+  behavior of "PercentageTest"
+
+  val p = Percentage(Time.name, Seconds.symbol, 86400d)
+
+  it should "update" in {
+    val q = p.update(86400 / 2, "s", Instant.now())
+    q.map(_.value) shouldBe Some(0.5)
+  }
+
+  it should "dimension" in {
+    p.dimension shouldBe "Time"
+  }
+
+  it should "value" in {
+    p.value shouldBe 0d
+  }
+
+  it should "baseParam" in {
+    p.baseParam shouldEqual 86400d
+  }
+
+  it should "params" in {
+    p.params.isEmpty shouldBe false
+    p.params.contains("base") shouldBe true
+    p.params.get("base") shouldBe Some(86400d)
+  }
+
+  it should "name" in {
+    p.name shouldBe "Percentage"
+  }
+
+}

--- a/src/test/scala/io/epiphanous/flinkrunner/model/aggregate/PercentageTest.scala
+++ b/src/test/scala/io/epiphanous/flinkrunner/model/aggregate/PercentageTest.scala
@@ -13,7 +13,7 @@ class PercentageTest extends FlatSpec with Matchers with LazyLogging {
 
   it should "update" in {
     val q = p.update(86400 / 2, "s", Instant.now())
-    q.map(_.value) shouldBe Some(0.5)
+    q.map(_.value) shouldBe Some(50)
   }
 
   it should "dimension" in {
@@ -31,7 +31,7 @@ class PercentageTest extends FlatSpec with Matchers with LazyLogging {
   it should "params" in {
     p.params.isEmpty shouldBe false
     p.params.contains("base") shouldBe true
-    p.params.get("base") shouldBe Some(86400d)
+    p.params.get("base") shouldBe Some("86400.0")
   }
 
   it should "name" in {


### PR DESCRIPTION
Adds a `Percentage` aggregate, following the `Aggregate` api in flinkrunner. 

## Usage

```scala
val pct = Aggregate("Percentage", dimension, unit, ..., base)
```
where the `dimension` is the dimension of the underlying metric being aggregated (often "Time"), `unit` is standard unit to be used in computations and `base` is the numeric (`Double`) value, in `unit` units, of the base of the percentage aggregation.

So if you want to compute the percentage of time spent during the day in active exercise, you might do this:

```scala
import squants.time.{Time, Seconds}
val pct = Aggregate("Percentage", Time.name, Seconds.symbol, base = Some(Time.SecondsPerDay))

pct.update(7200, "s", Instant.now())
pct.update(1, "hr", Instant.now())
```

After these updates, the aggregate's value would be `12.5%` (`3` hours out of `24`, or `10,800` seconds out of `86,400`).

It's possible, if not sensible, to aggregate to more than `100%`, so choose units and base carefully.

### Other Changes

* Refactor naming of aggregations, to make leveraging the generic `Aggregate()` factory more reliable
* Refactored the `params` field of aggregates to `Map[String, String]` instead of `Map[String, Any]`, to make its use more reliable