### PR TITLE
fix arg parsing

### DIFF
--- a/src/main/scala/io/epiphanous/flinkrunner/flink/BaseFlinkJob.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/flink/BaseFlinkJob.scala
@@ -17,7 +17,7 @@ import scala.collection.JavaConverters._
   * @tparam DS   The type of the input stream
   * @tparam OUT  The type of output stream elements
   */
-abstract class BaseFlinkJob[DS, OUT <: FlinkEvent: TypeInformation] extends LazyLogging {
+abstract class BaseFlinkJob[DS: TypeInformation, OUT <: FlinkEvent: TypeInformation] extends LazyLogging {
 
   /**
     * A pipeline for transforming a single stream. Passes the output of source()

--- a/src/main/scala/io/epiphanous/flinkrunner/model/FlinkConfig.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/FlinkConfig.scala
@@ -26,10 +26,11 @@ class FlinkConfig(
 
   val (jobName, jobArgs, jobParams) = {
     val (n, a) = args match {
-      case Array("help", _*)     => ("help", Array.empty[String])
-      case Array(jn, "help", _*) => (jn, Array("--help"))
-      case Array(jn, _*)         => (jn, args.tail)
-      case _                     => ("help", Array.empty[String])
+      case Array(opt, _*) if opt.startsWith("-") => ("help", args)
+      case Array("help", _*)                     => ("help", args.tail)
+      case Array(jn, "help", _*)                 => (jn, Array("--help") ++ args.tail)
+      case Array(jn, _*)                         => (jn, args.tail)
+      case _                                     => ("help", args)
     }
     (n, a, ParameterTool.fromArgs(a))
   }


### PR DESCRIPTION
Fixes two bugs when processing arguments in cases where people are asking for help. 

- When the word "help" is passed as the job name, any other arguments are ignored. However, when running on EMR, you need to set the environment so dev is not assumed and Flink tries to create a LocalEnvironment (which fails on EMR)
- When no name is passed, but other arguments are provided. Similar issue to above happened, and this PR fixes it.