### PR TITLE
fix arg parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@
 
 ## Maven Dependency
 
-`Flinkrunner` `v2.0.0` is now on maven central, built against Flink 1.8.2 with Scala 2.11 and JDK 8.
+`Flinkrunner` `v2.0.1` is now on maven central, built against Flink 1.8.2 with Scala 2.11 and JDK 8.
 
 ```sbtshell
-libraryDependencies += "io.epiphanous" %% "flinkrunner" % "2.0.0"
+libraryDependencies += "io.epiphanous" %% "flinkrunner" % "2.0.1"
 ```
 
 >The apache flink project doesn't include its AWS Kinesis connector on maven
@@ -68,14 +68,14 @@ Flink kinesis connector) from source. To do so,
     ```
 
 * Checkout the tag of `FlinkRunner` you want to build. The most recent stable version is
-  `v2.0.0`, but you can ensure you have the most recent tags with `git fetch --tags` and
+  `v2.0.1`, but you can ensure you have the most recent tags with `git fetch --tags` and
   list tags with `git tag -l`, then
 
     ```bash
-    git checkout tags/v2.0.0 -b my-build-v2.0.0
+    git checkout tags/v2.0.1 -b my-build-v2.0.1
     ```
 
-   This will create a new local branch `my-build-v2.0.0` based on the `v2.0.0` tag release.
+   This will create a new local branch `my-build-v2.0.1` based on the `v2.0.1` tag release.
 
 * Build `FlinkRunner` and install it locally, using the `-Dwith.kinesis=true` option
 
@@ -92,7 +92,7 @@ Flink kinesis connector) from source. To do so,
     resolvers += "Local Maven Repository" at "file://" +
         Path.userHome.absolutePath + "/.m2/repository"
     ...
-    libraryDependencies += "io.epiphanous" %% "flinkrunner" % "2.0.0k"
+    libraryDependencies += "io.epiphanous" %% "flinkrunner" % "2.0.1k"
                                       // notice no v here  ---^^    ^^---k for kinesis
     ```
 

--- a/src/main/scala/io/epiphanous/flinkrunner/flink/BaseFlinkJob.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/flink/BaseFlinkJob.scala
@@ -17,7 +17,7 @@ import scala.collection.JavaConverters._
   * @tparam DS   The type of the input stream
   * @tparam OUT  The type of output stream elements
   */
-abstract class BaseFlinkJob[DS, OUT <: FlinkEvent: TypeInformation] extends LazyLogging {
+abstract class BaseFlinkJob[DS: TypeInformation, OUT <: FlinkEvent: TypeInformation] extends LazyLogging {
 
   /**
     * A pipeline for transforming a single stream. Passes the output of source()

--- a/src/main/scala/io/epiphanous/flinkrunner/model/FlinkConfig.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/FlinkConfig.scala
@@ -26,10 +26,11 @@ class FlinkConfig(
 
   val (jobName, jobArgs, jobParams) = {
     val (n, a) = args match {
-      case Array("help", _*)     => ("help", Array.empty[String])
-      case Array(jn, "help", _*) => (jn, Array("--help"))
-      case Array(jn, _*)         => (jn, args.tail)
-      case _                     => ("help", Array.empty[String])
+      case Array(opt, _*) if opt.startsWith("-") => ("help", args)
+      case Array("help", _*)                     => ("help", args.tail)
+      case Array(jn, "help", _*)                 => (jn, Array("--help") ++ args.tail)
+      case Array(jn, _*)                         => (jn, args.tail)
+      case _                                     => ("help", args)
     }
     (n, a, ParameterTool.fromArgs(a))
   }


### PR DESCRIPTION
Fixes two bugs when processing arguments in cases where people are asking for help. 

- When the word "help" is passed as the job name, any other arguments are ignored. However, when running on EMR, you need to set the environment so dev is not assumed and Flink tries to create a LocalEnvironment (which fails on EMR)
- When no name is passed, but other arguments are provided. Similar issue to above happened, and this PR fixes it.