### PR TITLE
fixed serializer to work on latest schema

### DIFF
--- a/src/main/scala/io/epiphanous/flinkrunner/avro/ConfluentSchemaRegistryClient.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/avro/ConfluentSchemaRegistryClient.scala
@@ -184,12 +184,13 @@ class ConfluentSchemaRegistryClient()(implicit
             optContext.getOrElse(ConfluentSchemaRegistryContext()).version
           )
         )
-        .map(schema => putCache(schema, url(schema.id.toInt)))
-    magic <- Try {
+        .map(schema => putCache(schema, url(schema.id)))
+      magic <- Try {
+        logger.info(s"I am here")
                ByteBuffer
-                 .wrap(new Array[Byte](5))
+                 .wrap(new Array[Byte](50))
                  .put(0x0.toByte)
-                 .putInt(schema.id.toInt)
+                 .put(schema.id.getBytes())
                  .array()
              }
   } yield (schema, magic)


### PR DESCRIPTION
Hi Bob, this is a minor fix for current release function to support latest version of schema which earlier used to throw NumberFormatException because we were trying to convert "latest" to int `schema.id.toInt`. 
Because of this exception empty string was getting streamed to sink kafka topic.