### PR TITLE
remove scala dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@
   <img src="https://img.shields.io/travis/com/epiphanous/flinkrunner.svg" alt="build" />
 </a>
 <!-- coverage -->
-<a href='https://coveralls.io/github/epiphanous/flinkrunner?branch=main'><img 
-src='https://coveralls.io/repos/github/epiphanous/flinkrunner/badge.svg?branch=master' alt='Coverage Status' /></a>
+<a href='https://coveralls.io/github/epiphanous/flinkrunner?branch=main'><img src='https://coveralls.io/repos/github/epiphanous/flinkrunner/badge.svg?branch=main' alt='Coverage Status' /></a>
 </div>
 
 <div align="center">
@@ -258,7 +257,7 @@ Next, write some jobs! This is the fun part.
 ```
 class MyJob1(runner:FlinkRunner[MyEventADT]) extends StreamJob[MyEventA](runner) {
 
-  override def transform:DataStream[MyEventA] = 
+  override def transform:DataStream[MyEventA] =
     singleSource[MyEventA]()
 
 }
@@ -296,9 +295,9 @@ Next, wire up your runner to a main method.
 
   ```
   object Main {
-    def main(args:Array[String]) = 
+    def main(args:Array[String]) =
       new MyRunner(new FlinkConfig(args))
-  } 
+  }
   ```
 
 Finally, assemble an uber jar with all your dependencies, deploy it to your flink cluster,
@@ -318,7 +317,7 @@ flink jobs. If your output event types require avro support, you should instead 
 
 ```
 class StreamJob[
-  OUT <: ADT, 
+  OUT <: ADT,
   ADT <: FlinkEvent](runner:FlinkRunner[ADT])
 ```
 
@@ -426,8 +425,8 @@ graph defined by your `transform` method.
 
 ```
 class AvroStreamJob[
-  OUT <: ADT with EmbeddedAvroRecord[A], 
-  A<:GenericRecord, 
+  OUT <: ADT with EmbeddedAvroRecord[A],
+  A<:GenericRecord,
   ADT <: FlinkEvent](runner:FlinkRunner[ADT])
 ```
 
@@ -440,7 +439,7 @@ encoded sink (kafka or parquet-avro files).
 trait EmbeddedAvroRecord[A <: GenericRecord {
 
   def $recordKey: Option[String] = None
-  
+
   def $record: A
 
   def $recordHeaders: Map[String, String] = Map.empty
@@ -532,36 +531,36 @@ trait SinkConfig[ADT <: FlinkEvent]
 
 ```
 trait Aggregate {
-    
+
     def name:String
-    
+
     // the kind of measurement being aggregated
     def dimension: String
-    
+
     // the preferred unit of measurements being aggregated
     def unit: String
-    
+
     // the current aggregated value
     def value: Double
-    
+
     // the current count of measurements included in this aggregate
     def count: BigInt
-    
+
     // the timestamp of the most recent aggregated event
     def aggregatedLastUpdated: Instant
-    
+
     // the timestamp when this aggregate was last updated
     def lastUpdated: Instant
-    
+
     // other aggregations this aggregation depends on
     def dependentAggregations: Map[String, Aggregate]
-    
+
     // configuration parameters
     def params: Map[String, String]
-    
+
     // a method to update the aggregate with a new value
-    def update(value: Double, unit: String, 
-               aggLU: Instant): Try[Aggregate] 
+    def update(value: Double, unit: String,
+               aggLU: Instant): Try[Aggregate]
 }
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -54,9 +54,6 @@ val V = new {
 
 val flinkDeps =
   Seq(
-    // scala
-    "org.apache.flink" %% "flink-scala"                    % V.flink,
-    "org.apache.flink" %% "flink-streaming-scala"          % V.flink,
     // rocksdb
     "org.apache.flink"  % "flink-statebackend-rocksdb"     % V.flink,
     // queryable state
@@ -77,7 +74,6 @@ val flinkDeps =
     "org.apache.flink"  % "flink-avro"                     % V.flink % Provided, // ds and table avro format
     "org.apache.flink"  % "flink-avro-confluent-registry"  % V.flink % Provided, // ds and table avro registry format
     // table api support
-    "org.apache.flink" %% "flink-table-api-scala-bridge"   % V.flink, // table api scala
     "org.apache.flink"  % "flink-table-planner-loader"     % V.flink % Provided, // table api
     "org.apache.flink"  % "flink-table-runtime"            % V.flink % Provided, // table runtime
     "org.apache.flink"  % "flink-csv"                      % V.flink % Provided, // table api csv format

--- a/src/main/scala/io/epiphanous/flinkrunner/flink/AvroStreamJob.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/flink/AvroStreamJob.scala
@@ -4,7 +4,7 @@ import io.epiphanous.flinkrunner.FlinkRunner
 import io.epiphanous.flinkrunner.model.{EmbeddedAvroRecord, FlinkEvent}
 import org.apache.avro.generic.GenericRecord
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.streaming.api.scala.DataStream
+import org.apache.flink.streaming.api.datastream.DataStream
 
 /** A [[StreamJob]] with Avro inputs and outputs
   * @param runner

--- a/src/main/scala/io/epiphanous/flinkrunner/model/FlinkConfig.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/FlinkConfig.scala
@@ -13,7 +13,7 @@ import org.apache.flink.api.common.RuntimeExecutionMode
 import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend
 import org.apache.flink.runtime.state.hashmap.HashMapStateBackend
-import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 
 import java.io.File
 import java.time.Duration

--- a/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/WindowedAggregationInitializer.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/aggregate/WindowedAggregationInitializer.scala
@@ -2,7 +2,7 @@ package io.epiphanous.flinkrunner.model.aggregate
 
 import io.epiphanous.flinkrunner.model.{FlinkEvent, UnitMapper}
 import io.epiphanous.flinkrunner.operator.FlinkRunnerAggregateFunction
-import org.apache.flink.streaming.api.scala.function.ProcessWindowFunction
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction
 import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner
 import org.apache.flink.streaming.api.windowing.windows.Window
 import squants.{Dimension, Quantity, UnitOfMeasure}

--- a/src/main/scala/io/epiphanous/flinkrunner/model/sink/CassandraSinkConfig.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/sink/CassandraSinkConfig.scala
@@ -5,7 +5,7 @@ import io.epiphanous.flinkrunner.model.{
   FlinkConnectorName,
   FlinkEvent
 }
-import org.apache.flink.streaming.api.scala.DataStream
+import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.connectors.cassandra.CassandraSink
 
 /** A cassandra sink config.

--- a/src/main/scala/io/epiphanous/flinkrunner/model/sink/ElasticsearchSinkConfig.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/sink/ElasticsearchSinkConfig.scala
@@ -13,8 +13,10 @@ import org.apache.flink.connector.elasticsearch.sink.{
   ElasticsearchEmitter,
   FlushBackoffType
 }
-import org.apache.flink.streaming.api.datastream.DataStreamSink
-import org.apache.flink.streaming.api.scala.DataStream
+import org.apache.flink.streaming.api.datastream.{
+  DataStream,
+  DataStreamSink
+}
 import org.apache.http.HttpHost
 import org.elasticsearch.client.Requests
 

--- a/src/main/scala/io/epiphanous/flinkrunner/model/sink/FileSinkConfig.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/sink/FileSinkConfig.scala
@@ -11,7 +11,10 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.connector.file.sink.FileSink
 import org.apache.flink.core.fs.Path
 import org.apache.flink.core.io.SimpleVersionedSerializer
-import org.apache.flink.streaming.api.datastream.DataStreamSink
+import org.apache.flink.streaming.api.datastream.{
+  DataStream,
+  DataStreamSink
+}
 import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.{
   BasePathBucketAssigner,
   DateTimeBucketAssigner
@@ -24,7 +27,6 @@ import org.apache.flink.streaming.api.functions.sink.filesystem.{
   BucketAssigner,
   OutputFileConfig
 }
-import org.apache.flink.streaming.api.scala.DataStream
 
 import java.nio.charset.StandardCharsets
 import scala.collection.JavaConverters._

--- a/src/main/scala/io/epiphanous/flinkrunner/model/sink/JdbcSinkConfig.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/sink/JdbcSinkConfig.scala
@@ -17,8 +17,10 @@ import org.apache.flink.connector.jdbc.{
   JdbcExecutionOptions,
   JdbcStatementBuilder
 }
-import org.apache.flink.streaming.api.datastream.DataStreamSink
-import org.apache.flink.streaming.api.scala.DataStream
+import org.apache.flink.streaming.api.datastream.{
+  DataStream,
+  DataStreamSink
+}
 
 import java.sql.{Connection, DriverManager, Timestamp}
 import java.time.Instant

--- a/src/main/scala/io/epiphanous/flinkrunner/model/sink/KafkaSinkConfig.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/sink/KafkaSinkConfig.scala
@@ -16,8 +16,10 @@ import org.apache.flink.connector.kafka.sink.{
   KafkaRecordSerializationSchema,
   KafkaSink
 }
-import org.apache.flink.streaming.api.datastream.DataStreamSink
-import org.apache.flink.streaming.api.scala.DataStream
+import org.apache.flink.streaming.api.datastream.{
+  DataStream,
+  DataStreamSink
+}
 
 import java.util.Properties
 import scala.util.Try

--- a/src/main/scala/io/epiphanous/flinkrunner/model/sink/KinesisSinkConfig.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/sink/KinesisSinkConfig.scala
@@ -10,8 +10,10 @@ import io.epiphanous.flinkrunner.serde.JsonSerializationSchema
 import org.apache.flink.api.common.serialization.SerializationSchema
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.connector.kinesis.sink.KinesisStreamsSink
-import org.apache.flink.streaming.api.datastream.DataStreamSink
-import org.apache.flink.streaming.api.scala.DataStream
+import org.apache.flink.streaming.api.datastream.{
+  DataStream,
+  DataStreamSink
+}
 
 /**   - maxBatchSize: the maximum size of a batch of entries that may be
   *     sent to KDS

--- a/src/main/scala/io/epiphanous/flinkrunner/model/sink/RabbitMQSinkConfig.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/sink/RabbitMQSinkConfig.scala
@@ -10,8 +10,10 @@ import io.epiphanous.flinkrunner.model.{
 import io.epiphanous.flinkrunner.serde.JsonSerializationSchema
 import org.apache.flink.api.common.serialization.SerializationSchema
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.streaming.api.datastream.DataStreamSink
-import org.apache.flink.streaming.api.scala.DataStream
+import org.apache.flink.streaming.api.datastream.{
+  DataStream,
+  DataStreamSink
+}
 import org.apache.flink.streaming.connectors.rabbitmq.{
   RMQSink,
   RMQSinkPublishOptions

--- a/src/main/scala/io/epiphanous/flinkrunner/model/sink/SocketSinkConfig.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/sink/SocketSinkConfig.scala
@@ -10,9 +10,11 @@ import io.epiphanous.flinkrunner.model.{
 import io.epiphanous.flinkrunner.serde._
 import org.apache.flink.api.common.serialization.SerializationSchema
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.streaming.api.datastream.DataStreamSink
+import org.apache.flink.streaming.api.datastream.{
+  DataStream,
+  DataStreamSink
+}
 import org.apache.flink.streaming.api.functions.sink.SocketClientSink
-import org.apache.flink.streaming.api.scala.DataStream
 
 import java.nio.charset.StandardCharsets
 import scala.util.{Failure, Success}

--- a/src/main/scala/io/epiphanous/flinkrunner/model/source/FileSourceConfig.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/source/FileSourceConfig.scala
@@ -10,18 +10,15 @@ import org.apache.flink.api.common.eventtime.WatermarkStrategy
 import org.apache.flink.api.common.functions.FlatMapFunction
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.connector.source.{Source, SourceSplit}
-import org.apache.flink.api.scala.createTypeInformation
 import org.apache.flink.connector.file.src.FileSource
 import org.apache.flink.connector.file.src.reader.{
   StreamFormat,
   TextLineInputFormat
 }
 import org.apache.flink.core.fs.Path
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.functions.source.SourceFunction
-import org.apache.flink.streaming.api.scala.{
-  DataStream,
-  StreamExecutionEnvironment
-}
 import org.apache.flink.util.Collector
 
 import java.time.Duration
@@ -177,7 +174,7 @@ case class FileSourceConfig[ADT <: FlinkEvent](
       )
     }
     env
-      .fromSource(
+      .fromSource[String](
         fsb.build(),
         WatermarkStrategy.noWatermarks(),
         rawName
@@ -204,55 +201,6 @@ case class FileSourceConfig[ADT <: FlinkEvent](
       .name(s"wm:$label")
       .uid(s"wm:$label")
   }
-
-//  def flatMapTextAvroStream[
-//      E <: ADT with EmbeddedAvroRecord[A],
-//      A <: GenericRecord](
-//      decoder: EmbeddedAvroRowDecoder[E, A, ADT]): DataStream[E] = {}
-
-  /** Create a FileSource for avro parquet files.
-    * @param fromKV
-    *   a method, available in implicit scope, that creates an instance of
-    *   type E from an avro record of type A
-    * @tparam E
-    *   a type that is a member of the ADT and embeds an avro record of
-    *   type A
-    * @tparam A
-    *   an avro record (should be an instance of SpecificAvroRecord,
-    *   although the type here is looser)
-    * @return
-    */
-//  override def getAvroSource[
-//      E <: ADT with EmbeddedAvroRecord[A]: TypeInformation,
-//      A <: GenericRecord: TypeInformation](implicit
-//      fromKV: EmbeddedAvroRecordInfo[A] => E)
-//      : Either[SourceFunction[E], Source[E, _ <: SourceSplit, _]] = {
-//    require(
-//      format != StreamFormatName.Avro,
-//      badFormatAvroMessage
-//    )
-//    if (format == StreamFormatName.Parquet) {
-//      val fsb =
-//        FileSource.forRecordStreamFormat(
-//          new EmbeddedAvroParquetInputFormat[E, A, ADT](genericAvroSchema),
-//          origin
-//        )
-//      Right(
-//        (if (monitorDuration > 0)
-//           fsb.monitorContinuously(Duration.ofSeconds(monitorDuration))
-//         else fsb).build()
-//      )
-//    } else {
-//      val decoder =
-//        if (format == StreamFormatName.Json)
-//          new EmbeddedAvroJsonRowDecoder[E, A, ADT]()
-//        else
-//          new EmbeddedAvroDelimitedRowDecoder[E, A, ADT](delimitedConfig)
-//      flatMapTextStream(getTextFileStream(env))
-//
-//    }
-//
-//  }
 
   def getTextAvroSourceStream[
       E <: ADT with EmbeddedAvroRecord[A]: TypeInformation,

--- a/src/main/scala/io/epiphanous/flinkrunner/model/source/RabbitMQSourceConfig.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/source/RabbitMQSourceConfig.scala
@@ -9,11 +9,9 @@ import io.epiphanous.flinkrunner.model.{
 import io.epiphanous.flinkrunner.serde.JsonRMQDeserializationSchema
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.connector.source.{Source, SourceSplit}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.functions.source.SourceFunction
-import org.apache.flink.streaming.api.scala.{
-  DataStream,
-  StreamExecutionEnvironment
-}
 import org.apache.flink.streaming.connectors.rabbitmq.{
   RMQDeserializationSchema,
   RMQSource
@@ -65,7 +63,9 @@ case class RabbitMQSourceConfig[ADT <: FlinkEvent](
     )
 
   override def getSourceStream[E <: ADT: TypeInformation](
-      env: StreamExecutionEnvironment): DataStream[E] =
-    super.getSourceStream(env).setParallelism(1) // to ensure exactly once
+      env: StreamExecutionEnvironment): DataStream[E] = {
+    env.setParallelism(1) // to ensure exactly once
+    super.getSourceStream(env)
+  }
 
 }

--- a/src/main/scala/io/epiphanous/flinkrunner/model/source/SourceConfig.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/source/SourceConfig.scala
@@ -9,8 +9,9 @@ import org.apache.avro.generic.GenericRecord
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.connector.source.{Source, SourceSplit}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.functions.source.SourceFunction
-import org.apache.flink.streaming.api.scala._
 
 import java.time.Duration
 import java.util

--- a/src/main/scala/io/epiphanous/flinkrunner/operator/EnrichmentAsyncFunction.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/operator/EnrichmentAsyncFunction.scala
@@ -8,7 +8,7 @@ import com.typesafe.scalalogging.LazyLogging
 import io.circe.Decoder
 import io.epiphanous.flinkrunner.BuildInfo
 import io.epiphanous.flinkrunner.model.FlinkConfig
-import org.apache.flink.streaming.api.scala.async.{
+import org.apache.flink.streaming.api.functions.async.{
   ResultFuture,
   RichAsyncFunction
 }
@@ -35,6 +35,7 @@ import scala.concurrent.{
   Future
 }
 import scala.util.{Failure, Success, Try}
+import collection.JavaConverters._
 
 /** An abstract asynchronous function to enrich a data stream with
   * non-stream data. This class relies on guava's CacheBuilder to load and
@@ -250,7 +251,7 @@ abstract class EnrichmentAsyncFunction[
           throwable
         )
         collector.completeExceptionally(throwable)
-      case Success(results)   => collector.complete(results)
+      case Success(results)   => collector.complete(results.asJava)
     }
 
   /** A helper method to enable testing of asyncInvoke() without needing to

--- a/src/main/scala/io/epiphanous/flinkrunner/operator/SBFDeduplicationFilter.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/operator/SBFDeduplicationFilter.scala
@@ -12,7 +12,6 @@ import org.apache.flink.api.common.state.{
   ValueStateDescriptor
 }
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.api.scala._
 import org.apache.flink.configuration.Configuration
 
 /** A stable bloom filter for deduplicating event streams.
@@ -71,13 +70,13 @@ class SBFDeduplicationFilter[E <: ADT: TypeInformation, ADT <: FlinkEvent](
             bitsPerCell,
             falsePositiveRate
           ),
-          createTypeInformation[StableBloomFilter[CharSequence]]
+          classOf[StableBloomFilter[CharSequence]]
         )
       )
     dupCount = getRuntimeContext.getState(
       new ValueStateDescriptor[Long](
         s"${sourceConfig.label}_DuplicateCount",
-        createTypeInformation[Long]
+        classOf[Long]
       )
     )
   }

--- a/src/main/scala/io/epiphanous/flinkrunner/serde/AvroJsonSerializer.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/serde/AvroJsonSerializer.scala
@@ -8,7 +8,6 @@ import org.apache.avro.Schema
 import org.apache.avro.Schema.Type._
 import org.apache.avro.generic.GenericRecord
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.api.scala.createTypeInformation
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._

--- a/src/test/scala/io/epiphanous/flinkrunner/model/GeneratorConfigTest.scala
+++ b/src/test/scala/io/epiphanous/flinkrunner/model/GeneratorConfigTest.scala
@@ -1,0 +1,109 @@
+package io.epiphanous.flinkrunner.model
+
+import io.epiphanous.flinkrunner.PropSpec
+
+import java.time.{Duration, Instant}
+import java.util.Properties
+
+class GeneratorConfigTest extends PropSpec {
+
+  def gc: GeneratorConfig                   = GeneratorConfig("test", seedOpt = Some(123L))
+  val firstBoolean: Boolean                 = gc.rng.nextBoolean()
+  val firstString: String                   = gc.getRandString()
+  def firstStringOfLength(len: Int): String = gc.getRandString(len)
+  val firstDouble: Double                   = gc.rng.nextDouble()
+  val firstInt: Int                         = gc.rng.nextInt()
+  def firstBoundedInt(bound: Int): Int      = gc.rng.nextInt(bound)
+  val firstLong: Long                       = gc.rng.nextLong()
+
+  property("startTime property") {
+    gc
+      .copy(startAgo = Duration.ZERO)
+      .startTime
+      .minusMillis(Instant.now().toEpochMilli)
+      .toEpochMilli shouldEqual 0L
+  }
+
+  property("timeSequence property") {
+    gc
+      .copy(startAgo = Duration.ZERO)
+      .timeSequence
+      .addAndGet(
+        -Instant.now().toEpochMilli
+      ) shouldEqual 0L +- 2L
+  }
+
+  property("maxRows property") {
+    gc.copy(maxRows = 10).maxRows shouldEqual 10L
+    gc.maxRows shouldEqual -1L
+  }
+
+  property("getRandInt bounded property") {
+    gc.getRandInt(10) should (be >= 0 and be <= 10)
+    gc.getRandInt(10) shouldEqual firstBoundedInt(10)
+  }
+
+  property("getRandInt property") {
+    gc.getRandInt should (be >= Int.MinValue and be <= Int.MaxValue)
+    gc.getRandInt shouldEqual firstInt
+  }
+
+  property("getProp property") {
+    gc.getProp("not.there", 10).shouldEqual(10)
+    val props = new Properties()
+    props.setProperty("now.its.there", "10")
+    gc.copy(properties = props).getProp("now.its.there", -1) shouldEqual 10
+  }
+
+  property("maxTimeStep property") {
+    gc.maxTimeStep shouldEqual 100
+    gc.copy(maxTimeStep = 250).maxTimeStep shouldEqual 250
+  }
+
+  property("seedOpt property") {
+    gc.seedOpt.value shouldEqual 123L
+  }
+
+  property("probNull property") {
+    gc.probNull shouldEqual 0
+  }
+
+  property("wantsNull property") {
+    gc.wantsNull shouldEqual false
+    gc.copy(probNull = firstDouble * .8).wantsNull shouldEqual false
+    gc.copy(probNull = firstDouble * 1.2).wantsNull shouldEqual true
+  }
+
+  property("startAgo property") {
+    gc.startAgo shouldEqual Duration.ofDays(365)
+  }
+
+  property("getRandString property") {
+    gc.getRandString().length should be <= 20
+    gc.getRandString(10).length should be <= 10
+    gc.getRandString() should fullyMatch regex "[A-Za-z0-9]+"
+    gc.getRandString() shouldEqual firstString
+  }
+
+  property("getRandBoolean property") {
+    gc.getRandBoolean shouldEqual firstBoolean
+  }
+
+  property("getRandDouble property") {
+    gc.getRandDouble shouldEqual firstDouble
+  }
+
+  property("getAndProgressTime property") {
+    val myGc = gc
+    myGc.getAndProgressTime() shouldEqual myGc.startTime.toEpochMilli
+    myGc.getAndProgressTime() should be <= myGc.startTime
+      .plusMillis(myGc.maxTimeStep)
+      .toEpochMilli
+  }
+
+  property("probOutOfOrder property") {
+    gc.probOutOfOrder shouldEqual 0
+    gc.copy(probOutOfOrder = .5).probOutOfOrder shouldEqual .5
+  }
+
+}


### PR DESCRIPTION
Now that flinkrunner is built against Flink 1.15, we should remove our dependencies on any flink/scala libraries to support compiling flink runner with any version of scala.