### PR TITLE
Fix: only run create_hypertable on new tables

### DIFF
--- a/src/main/scala/io/epiphanous/flinkrunner/model/sink/JdbcSinkConfig.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/sink/JdbcSinkConfig.scala
@@ -531,11 +531,12 @@ case class JdbcSinkConfig[ADT <: FlinkEvent](
         sqlBuilder.append(");").getSqlAndClear
       }
 
-      logger.info(
-        s"creating hypertable for [$table]: \n====\n$createHypertableDml\n====\n"
-      )
-
-      stmt.executeQuery(createHypertableDml)
+      if (createTable) {
+        logger.info(
+          s"creating hypertable for [$table]: \n====\n$createHypertableDml\n====\n"
+        )
+        stmt.executeQuery(createHypertableDml)
+      }
     }
 
     stmt.close()


### PR DESCRIPTION
At the moment `create_hypertable` will execute on existing tables causing an error. 

The following change, checks `if (createTable)` which only runs _the first_ time a table is added to the database.