### PR TITLE
add kafka info headers to deserialized avro messages

### DIFF
--- a/src/main/scala/io/epiphanous/flinkrunner/flink/state/RichStateUtils.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/flink/state/RichStateUtils.scala
@@ -2,11 +2,13 @@ package io.epiphanous.flinkrunner.flink.state
 import scala.collection.JavaConverters._
 
 object RichStateUtils {
-  implicit class RichListState[T](listState: org.apache.flink.api.common.state.ListState[T]) {
-    def _iterator: Iterator[T] = listState.get().iterator().asScala
-    def isEmpty: Boolean = _iterator.isEmpty
+  implicit class RichListState[T](
+      listState: org.apache.flink.api.common.state.ListState[T]) {
+    def _iterator: Iterator[T]        = listState.get().iterator().asScala
+    def isEmpty: Boolean              = _iterator.isEmpty
     def contains(element: T): Boolean = _iterator.contains(element)
-    def find(element: T) : Option[T]= _iterator.find(v => v.equals(element))
-    def length: Int = _iterator.length
+    def find(element: T): Option[T]   =
+      _iterator.find(v => v.equals(element))
+    def length: Int                   = _iterator.length
   }
 }

--- a/src/main/scala/io/epiphanous/flinkrunner/model/KafkaInfoHeader.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/KafkaInfoHeader.scala
@@ -1,0 +1,22 @@
+package io.epiphanous.flinkrunner.model
+
+import enumeratum._
+
+import scala.collection.immutable
+
+sealed trait KafkaInfoHeader extends EnumEntry
+
+object KafkaInfoHeader extends Enum[KafkaInfoHeader] {
+
+  case object SerializedValueSize extends KafkaInfoHeader
+  case object SerializedKeySize   extends KafkaInfoHeader
+  case object Offset              extends KafkaInfoHeader
+  case object Partition           extends KafkaInfoHeader
+  case object Timestamp           extends KafkaInfoHeader
+  case object TimestampType       extends KafkaInfoHeader
+  case object Topic               extends KafkaInfoHeader
+
+  def headerName(h: KafkaInfoHeader) = s"Kafka.${h.entryName}"
+
+  override def values: immutable.IndexedSeq[KafkaInfoHeader] = findValues
+}

--- a/src/main/scala/io/epiphanous/flinkrunner/serde/AvroJsonSerializer.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/serde/AvroJsonSerializer.scala
@@ -45,37 +45,37 @@ class AvroJsonSerializer
       gen: JsonGenerator,
       provider: SerializerProvider): Unit = {
     (schema.getType, value) match {
-      case (NULL, _)                             => gen.writeNullField(name)
-      case (_, null | None)                      => gen.writeNullField(name)
-      case (_, Some(v))                          =>
+      case (NULL, _)                               => gen.writeNullField(name)
+      case (_, null | None)                        => gen.writeNullField(name)
+      case (_, Some(v))                            =>
         _serializeAvroValue(name, v, schema, gen, provider)
-      case (RECORD, record: GenericRecord)       =>
+      case (RECORD, record: GenericRecord)         =>
         gen.writeFieldName(name)
         serialize(record, gen, provider)
-      case (ENUM, ord: Int)                      =>
+      case (ENUM, ord: Int)                        =>
         gen.writeStringField(name, schema.getEnumSymbols.get(ord))
-      case (ARRAY, seq: Seq[_])                  =>
+      case (ARRAY, seq: Seq[_])                    =>
         gen.writeArrayFieldStart(name)
         seq.foreach { e =>
           _serializeElement(e, schema.getElementType, gen, provider)
         }
         gen.writeEndArray()
-      case (MAP, map: Map[String, _] @unchecked) =>
+      case (MAP, map: Map[String, Any] @unchecked) =>
         gen.writeObjectFieldStart(name)
         map.foreach { case (k, e) =>
           gen.writeFieldName(k)
           _serializeElement(e, schema.getValueType, gen, provider)
         }
         gen.writeEndObject()
-      case (UNION, _)                            =>
-        // todo: not a very sophisticated way to process unions, but it covers common case of [null, type]
+      case (UNION, _)                              =>
         val nonNullTypes =
           schema.getTypes.asScala.filterNot(s => s.getType == NULL)
-        if (nonNullTypes.size > 1) {
-          throw new RuntimeException(
-            s"field $name of type union has more than one non-null type: $nonNullTypes"
-          )
-        }
+//        if (nonNullTypes.size > 1) {
+//          throw new RuntimeException(
+//            s"field $name of type union has more than one non-null type: $nonNullTypes"
+//          )
+//        }
+
         _serializeAvroValue(
           name,
           value,
@@ -83,18 +83,18 @@ class AvroJsonSerializer
           gen,
           provider
         )
-      case (FIXED | BYTES, bytes: Array[Byte])   =>
+      case (FIXED | BYTES, bytes: Array[Byte])     =>
         gen.writeBinaryField(name, bytes)
-      case (STRING, string: String)              =>
+      case (STRING, string: String)                =>
         gen.writeStringField(name, string)
-      case (INT, int: Int)                       =>
+      case (INT, int: Int)                         =>
         gen.writeNumberField(name, int)
-      case (LONG, long: Long)                    => gen.writeNumberField(name, long)
-      case (FLOAT, float: Float)                 => gen.writeNumberField(name, float)
-      case (DOUBLE, double: Double)              => gen.writeNumberField(name, double)
-      case (BOOLEAN, boolean: Boolean)           =>
+      case (LONG, long: Long)                      => gen.writeNumberField(name, long)
+      case (FLOAT, float: Float)                   => gen.writeNumberField(name, float)
+      case (DOUBLE, double: Double)                => gen.writeNumberField(name, double)
+      case (BOOLEAN, boolean: Boolean)             =>
         gen.writeBooleanField(name, boolean)
-      case _                                     =>
+      case _                                       =>
         gen.writeFieldName(name)
         provider
           .findValueSerializer(

--- a/src/main/scala/io/epiphanous/flinkrunner/serde/ConfluentAvroRegistryKafkaRecordDeserializationSchema.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/serde/ConfluentAvroRegistryKafkaRecordDeserializationSchema.scala
@@ -1,13 +1,13 @@
 package io.epiphanous.flinkrunner.serde
 
 import com.typesafe.scalalogging.LazyLogging
+import io.epiphanous.flinkrunner.model.KafkaInfoHeader._
 import io.epiphanous.flinkrunner.model.source.KafkaSourceConfig
 import io.epiphanous.flinkrunner.model.{
   EmbeddedAvroRecord,
   EmbeddedAvroRecordInfo,
   FlinkEvent
 }
-import io.epiphanous.flinkrunner.model.KafkaInfoHeader._
 import io.epiphanous.flinkrunner.util.AvroUtils.{
   isSpecific,
   schemaOf,

--- a/src/main/scala/io/epiphanous/flinkrunner/serde/ConfluentAvroRegistryKafkaRecordDeserializationSchema.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/serde/ConfluentAvroRegistryKafkaRecordDeserializationSchema.scala
@@ -73,7 +73,7 @@ class ConfluentAvroRegistryKafkaRecordDeserializationSchema[
       .map(_.asScala.map { h =>
         (h.key(), new String(h.value(), StandardCharsets.UTF_8))
       }.toMap)
-      .getOrElse(Map.empty[String, String]) ++ (
+      .getOrElse(Map.empty[String, String]) ++ Map(
       headerName(SerializedValueSize) -> record
         .serializedValueSize()
         .toString,

--- a/src/main/scala/io/epiphanous/flinkrunner/serde/ConfluentAvroRegistryKafkaRecordDeserializationSchema.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/serde/ConfluentAvroRegistryKafkaRecordDeserializationSchema.scala
@@ -7,6 +7,7 @@ import io.epiphanous.flinkrunner.model.{
   EmbeddedAvroRecordInfo,
   FlinkEvent
 }
+import io.epiphanous.flinkrunner.model.KafkaInfoHeader._
 import io.epiphanous.flinkrunner.util.AvroUtils.{
   isSpecific,
   schemaOf,
@@ -72,7 +73,21 @@ class ConfluentAvroRegistryKafkaRecordDeserializationSchema[
       .map(_.asScala.map { h =>
         (h.key(), new String(h.value(), StandardCharsets.UTF_8))
       }.toMap)
-      .getOrElse(Map.empty[String, String])
+      .getOrElse(Map.empty[String, String]) ++ (
+      headerName(SerializedValueSize) -> record
+        .serializedValueSize()
+        .toString,
+      headerName(SerializedKeySize)   -> record
+        .serializedKeySize()
+        .toString,
+      headerName(Offset)              -> record.offset().toString,
+      headerName(Partition)           -> record.partition().toString,
+      headerName(Timestamp)           -> record.timestamp().toString,
+      headerName(TimestampType)       -> record
+        .timestampType()
+        .name(),
+      headerName(Topic)               -> record.topic()
+    )
 
     val key = Option(record.key()).map(keyBytes =>
       new String(keyBytes, StandardCharsets.UTF_8)

--- a/src/test/scala/io/epiphanous/flinkrunner/flink/state/RichStateUtilsTests.scala
+++ b/src/test/scala/io/epiphanous/flinkrunner/flink/state/RichStateUtilsTests.scala
@@ -1,31 +1,35 @@
 package io.epiphanous.flinkrunner.flink.state
 
+import io.epiphanous.flinkrunner.UnitSpec
+import io.epiphanous.flinkrunner.flink.state.RichStateUtils._
+import org.apache.flink.api.common.state.ListStateDescriptor
+import org.apache.flink.api.java.functions.KeySelector
+import org.apache.flink.configuration.Configuration
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration
+import org.apache.flink.streaming.api.datastream.DataStreamSource
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.streaming.api.functions.ProcessFunction
 import org.apache.flink.streaming.api.functions.sink.SinkFunction
+import org.apache.flink.streaming.api.functions.source.SourceFunction
+import org.apache.flink.streaming.api.scala.createTypeInformation
 import org.apache.flink.test.util.MiniClusterWithClientResource
+import org.apache.flink.util.Collector
 import org.scalatest.BeforeAndAfter
 import org.scalatest.matchers.should.Matchers
 
 import java.util
 import java.util.Collections
-import org.apache.flink.api.common.state.ListStateDescriptor
-import org.apache.flink.api.java.functions.KeySelector
-import org.apache.flink.configuration.Configuration
-import org.apache.flink.streaming.api.datastream.DataStreamSource
-import org.apache.flink.streaming.api.functions.ProcessFunction
-import org.apache.flink.streaming.api.functions.source.SourceFunction
-import org.apache.flink.streaming.api.scala.createTypeInformation
-import org.apache.flink.util.Collector
-import io.epiphanous.flinkrunner.UnitSpec
+class RichStateUtilsTests
+    extends UnitSpec
+    with Matchers
+    with BeforeAndAfter {
 
-import RichStateUtils._
-class RichStateUtilsTests extends UnitSpec with Matchers with BeforeAndAfter {
-
-  val flinkCluster = new MiniClusterWithClientResource(new MiniClusterResourceConfiguration.Builder()
-    .setNumberSlotsPerTaskManager(2)
-    .setNumberTaskManagers(1)
-    .build)
+  val flinkCluster = new MiniClusterWithClientResource(
+    new MiniClusterResourceConfiguration.Builder()
+      .setNumberSlotsPerTaskManager(2)
+      .setNumberTaskManagers(1)
+      .build
+  )
 
   before {
     flinkCluster.before()
@@ -35,75 +39,90 @@ class RichStateUtilsTests extends UnitSpec with Matchers with BeforeAndAfter {
     flinkCluster.after()
   }
 
-
   "RichListStateTest1 pipeline" should "implement all members" in {
 
     CollectSink.values.clear()
 
-    val env : StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment()
+    val env: StreamExecutionEnvironment =
+      StreamExecutionEnvironment.getExecutionEnvironment()
 
-    val dataStream : DataStreamSource[Integer] = env.addSource(new SourceFunction[Integer] {
-      override def run(ctx: SourceFunction.SourceContext[Integer]): Unit = {
-        for( x <- 1 until 3) {
-          val data = List.fill(1)(List(1, 2, 3, 4)).flatten
-          for (x <- data) {
-            ctx.collect(new Integer(x))
+    val dataStream: DataStreamSource[Integer] =
+      env.addSource(new SourceFunction[Integer] {
+        override def run(
+            ctx: SourceFunction.SourceContext[Integer]): Unit = {
+          for (x <- 1 until 3) {
+            val data = List.fill(1)(List(1, 2, 3, 4)).flatten
+            for (x <- data)
+              ctx.collect(new Integer(x))
           }
         }
-      }
 
-      override def cancel(): Unit = ???
-    })
+        override def cancel(): Unit = ???
+      })
 
-    dataStream.keyBy(new KeySelector[Integer, Integer] {
-      override def getKey(value: Integer): Integer = {
-        value
-      }
-    }).process(new ProcessFunction[Integer, Integer] {
+    dataStream
+      .keyBy(new KeySelector[Integer, Integer] {
+        override def getKey(value: Integer): Integer =
+          value
+      })
+      .process(new ProcessFunction[Integer, Integer] {
 
-      var listState: org.apache.flink.api.common.state.ListState[Integer] = _
+        var listState
+            : org.apache.flink.api.common.state.ListState[Integer] = _
 
-      override def open(parameters: Configuration): Unit = {
-        this.listState = getRuntimeContext.getListState(new ListStateDescriptor[Integer](
-          "foo",
-          createTypeInformation[Integer]
-        ))
-      }
-      override def processElement(value: Integer, ctx: ProcessFunction[Integer, Integer]#Context, out: Collector[Integer]): Unit = {
-
-        // These groups of related functions should yield functionality equivalent results
-        assert(
-          (this.listState.isEmpty && this.listState.length <= 0)
-          ||
-          (!this.listState.isEmpty && this.listState.length > 0)
-        )
-
-        assert(
-          (this.listState.contains(value) && this.listState.find(value).get.equals(value))
-          ||
-          (!this.listState.contains(value) && this.listState.find(value).isEmpty)
-        )
-
-        if(!this.listState.isEmpty && this.listState.contains(value)) {
-          // collects (2, 4, 6, 8) [ yields 4 elements ]
-          out.collect(value * 2)
-          // collects (1, 2, 3, 4) [ yields 4 elements ]
-          out.collect(this.listState.find(value).get)
+        override def open(parameters: Configuration): Unit = {
+          this.listState = getRuntimeContext.getListState(
+            new ListStateDescriptor[Integer](
+              "foo",
+              createTypeInformation[Integer]
+            )
+          )
         }
-        listState.add(value)
-      }
-    }).addSink(new CollectSink())
+        override def processElement(
+            value: Integer,
+            ctx: ProcessFunction[Integer, Integer]#Context,
+            out: Collector[Integer]): Unit = {
+
+          // These groups of related functions should yield functionality equivalent results
+          assert(
+            (this.listState.isEmpty && this.listState.length <= 0)
+              ||
+                (!this.listState.isEmpty && this.listState.length > 0)
+          )
+
+          assert(
+            (this.listState.contains(value) && this.listState
+              .find(value)
+              .get
+              .equals(value))
+              ||
+                (!this.listState
+                  .contains(value) && this.listState.find(value).isEmpty)
+          )
+
+          if (!this.listState.isEmpty && this.listState.contains(value)) {
+            // collects (2, 4, 6, 8) [ yields 4 elements ]
+            out.collect(value * 2)
+            // collects (1, 2, 3, 4) [ yields 4 elements ]
+            out.collect(this.listState.find(value).get)
+          }
+          listState.add(value)
+        }
+      })
+      .addSink(new CollectSink())
 
     env.execute("ListStateTestLocalJob")
-    CollectSink.values should contain allOf(1, 2, 3, 4, 6, 8)
+    CollectSink.values should contain allOf (1, 2, 3, 4, 6, 8)
   }
 }
 
 private class CollectSink extends SinkFunction[Integer] {
-  override def invoke(value: Integer, context: SinkFunction.Context): Unit = {
+  override def invoke(
+      value: Integer,
+      context: SinkFunction.Context): Unit =
     CollectSink.values.add(value)
-  }
 }
 private object CollectSink {
-  val values: util.List[Integer] = Collections.synchronizedList(new util.ArrayList())
+  val values: util.List[Integer] =
+    Collections.synchronizedList(new util.ArrayList())
 }

--- a/src/test/scala/io/epiphanous/flinkrunner/model/sink/SimpleAvroIdentityJob.scala
+++ b/src/test/scala/io/epiphanous/flinkrunner/model/sink/SimpleAvroIdentityJob.scala
@@ -2,7 +2,11 @@ package io.epiphanous.flinkrunner.model.sink
 
 import io.epiphanous.flinkrunner.FlinkRunner
 import io.epiphanous.flinkrunner.flink.AvroStreamJob
-import io.epiphanous.flinkrunner.model.{EmbeddedAvroRecord, EmbeddedAvroRecordInfo, MyAvroADT}
+import io.epiphanous.flinkrunner.model.{
+  EmbeddedAvroRecord,
+  EmbeddedAvroRecordInfo,
+  MyAvroADT
+}
 import org.apache.avro.generic.GenericRecord
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.scala.createTypeInformation


### PR DESCRIPTION
This PR adds one new feature and improves an existing feature:
- (new feature) Add metadata about the deserialized avro message to headers of embedded avro event
- (improvement) Improve serialization of Avro records