### PR TITLE
Add JdbcConnectionProvider that supports more connection properties

### DIFF
--- a/src/main/scala/io/epiphanous/flinkrunner/model/BasicJdbcConnectionProvider.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/BasicJdbcConnectionProvider.scala
@@ -1,0 +1,64 @@
+package io.epiphanous.flinkrunner.model
+
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.flink.connector.jdbc.JdbcConnectionOptions
+import org.apache.flink.connector.jdbc.internal.connection.JdbcConnectionProvider
+
+import java.sql.{Connection, DriverManager}
+import java.util.Properties
+import scala.util.Try
+
+/** A basic replacement for flink's SimpleJdbcConnectionProvider, which
+  * does not allow using other properties besides user and password when
+  * establishing a jdbc connection. This is useful for some jdbc drivers
+  * that require more complex security credentials or other special
+  * properties to establish a connection.
+  * @param jdbcOptions
+  *   a flink JdbcConnectionOptions object
+  * @param props
+  *   arbitrary properties to provide the driver during connection
+  */
+@SerialVersionUID(2022083817L)
+class BasicJdbcConnectionProvider(
+    jdbcOptions: JdbcConnectionOptions,
+    props: Properties = new Properties())
+    extends JdbcConnectionProvider
+    with LazyLogging
+    with Serializable {
+
+  val url: String = jdbcOptions.getDbURL
+
+  jdbcOptions.getUsername.ifPresent(user =>
+    props.setProperty("user", user)
+  )
+  jdbcOptions.getPassword.ifPresent(pwd =>
+    props.setProperty("password", pwd)
+  )
+
+  @transient
+  var connection: Connection = _
+
+  override def getConnection: Connection = connection
+
+  override def getOrEstablishConnection(): Connection =
+    Option(connection).getOrElse {
+      Option(jdbcOptions.getDriverName).map(Class.forName)
+      connection = DriverManager.getConnection(url, props)
+      connection
+    }
+
+  override def isConnectionValid: Boolean = Option(connection).exists(c =>
+    c.isValid(jdbcOptions.getConnectionCheckTimeoutSeconds)
+  )
+
+  override def closeConnection(): Unit =
+    Try(Option(connection).map(_.close())).fold(
+      err => logger.warn("Failed to close jdbc connection", err),
+      _ => ()
+    )
+
+  override def reestablishConnection(): Connection = {
+    closeConnection()
+    getOrEstablishConnection()
+  }
+}

--- a/src/main/scala/io/epiphanous/flinkrunner/model/sink/JdbcSinkConfig.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/sink/JdbcSinkConfig.scala
@@ -18,7 +18,6 @@ import org.apache.flink.api.common.functions.RuntimeContext
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.connector.jdbc.internal.JdbcOutputFormat
 import org.apache.flink.connector.jdbc.internal.JdbcOutputFormat.StatementExecutorFactory
-import org.apache.flink.connector.jdbc.internal.connection.SimpleJdbcConnectionProvider
 import org.apache.flink.connector.jdbc.internal.executor.JdbcBatchStatementExecutor
 import org.apache.flink.connector.jdbc.{
   JdbcConnectionOptions,
@@ -292,17 +291,7 @@ case class JdbcSinkConfig[ADT <: FlinkEvent](
     buildColumnList()
     sqlBuilder.append(")\nVALUES (")
     Range(0, columns.length).foreach { i =>
-      <<<<<<< Updated upstream
       sqlBuilder.append("?")
-      =======
-      (columns(i).dataType, product) match {
-        case (SqlColumnType.JSON, SupportedDatabase.Snowflake)  =>
-          sqlBuilder.append("PARSE_JSON(?)")
-        case (SqlColumnType.JSON, SupportedDatabase.Postgresql) =>
-          sqlBuilder.append("CAST(? AS JSON)")
-        case _                                                  => sqlBuilder.append("?")
-      }
-      >>>>>>> Stashed changes
       if (i < columns.length - 1) sqlBuilder.append(", ")
     }
     sqlBuilder.append(")")

--- a/src/test/scala/io/epiphanous/flinkrunner/model/BasicJdbcConnectionProviderSpec.scala
+++ b/src/test/scala/io/epiphanous/flinkrunner/model/BasicJdbcConnectionProviderSpec.scala
@@ -1,0 +1,111 @@
+package io.epiphanous.flinkrunner.model
+
+import com.dimafeng.testcontainers.PostgreSQLContainer
+import io.epiphanous.flinkrunner.PropSpec
+import org.apache.flink.connector.jdbc.JdbcConnectionOptions
+import org.apache.flink.connector.jdbc.JdbcConnectionOptions.JdbcConnectionOptionsBuilder
+import org.scalatest
+
+import java.sql.Connection
+import scala.util.Try
+
+class BasicJdbcConnectionProviderSpec extends PropSpec {
+
+  val pgContainer: PostgreSQLContainer = PostgreSQLContainer()
+
+  def getJdbcConnectionOptions(
+      url: String,
+      driverNameOpt: Option[String] = None,
+      userOpt: Option[String] = None,
+      passwordOpt: Option[String] = None,
+      timeoutOpt: Option[Int] = None): JdbcConnectionOptions = {
+    val b = new JdbcConnectionOptionsBuilder().withUrl(url)
+    driverNameOpt.foreach(b.withDriverName)
+    userOpt.foreach(b.withUsername)
+    passwordOpt.foreach(b.withPassword)
+    timeoutOpt.foreach(b.withConnectionCheckTimeoutSeconds)
+    b.build()
+  }
+
+  def getConnectionProvider = new BasicJdbcConnectionProvider(
+    getJdbcConnectionOptions(
+      pgContainer.jdbcUrl,
+      driverNameOpt = Some(pgContainer.driverClassName),
+      userOpt = Some(pgContainer.username),
+      passwordOpt = Some(pgContainer.password)
+    )
+  )
+
+  property("getOrEstablishConnection property") {
+    Try {
+      pgContainer.start()
+      val c = getConnectionProvider.getOrEstablishConnection()
+      Option(c).isEmpty shouldBe false
+      pgContainer.stop()
+    } shouldBe 'success
+  }
+
+  def testConnectionProperty(
+      conn: BasicJdbcConnectionProvider => Connection)
+      : scalatest.Assertion = {
+    Try {
+      pgContainer.start()
+      val provider = getConnectionProvider
+      Option(conn(provider)).isEmpty shouldBe true
+      val c        = provider.getOrEstablishConnection()
+      conn(provider) shouldEqual c
+      pgContainer.stop()
+    } shouldBe 'success
+  }
+
+  property("connection property") {
+    testConnectionProperty((provider: BasicJdbcConnectionProvider) =>
+      provider.connection
+    )
+  }
+
+  property("getConnection property") {
+    testConnectionProperty((provider: BasicJdbcConnectionProvider) =>
+      provider.getConnection
+    )
+  }
+
+  property("url property") {
+    new BasicJdbcConnectionProvider(
+      getJdbcConnectionOptions("test-url")
+    ).url shouldEqual "test-url"
+  }
+
+  property("isConnectionValid property") {
+    Try {
+      pgContainer.start()
+      val provider = getConnectionProvider
+      provider.isConnectionValid shouldBe false
+      provider.getOrEstablishConnection()
+      provider.isConnectionValid shouldBe true
+      pgContainer.stop()
+    } shouldBe 'success
+  }
+
+  property("closeConnection property") {
+    Try {
+      pgContainer.start()
+      val provider = getConnectionProvider
+      provider.closeConnection() // doesn't throw if no connection exists
+      val c = provider.getOrEstablishConnection()
+      provider.closeConnection()
+      c.isClosed shouldBe true
+    } shouldBe 'success
+  }
+
+  property("reestablishConnection property") {
+    Try {
+      pgContainer.start()
+      val provider = getConnectionProvider
+      val c        = provider.reestablishConnection()
+      val c2       = provider.reestablishConnection()
+      c shouldEqual c2
+    } shouldBe 'success
+  }
+
+}


### PR DESCRIPTION
This small feature adds `BasicJdbConnectionProvider`, a `JdbcConnectionProvider` implementation that supports using arbitrary properties when opening a JDBC connection, as opposed to the built-in flink `SimpleJdbcConnectionProvider` which is limited to only `user` and `password`. This enables connecting to databases that require more properties to successfully connect, like Snowflake.