### PR TITLE
Fix formatting of instant into string

### DIFF
--- a/src/main/scala/io/epiphanous/flinkrunner/util/InstantUtils.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/util/InstantUtils.scala
@@ -1,12 +1,12 @@
 package io.epiphanous.flinkrunner.util
 
-import java.time.Instant
+import java.time.{Instant, ZoneOffset}
 import java.time.format.DateTimeFormatter
 
 object InstantUtils {
 
   val dtf: DateTimeFormatter =
-    DateTimeFormatter.ofPattern("/yyyy/MM/dd/HH")
+    DateTimeFormatter.ofPattern("/yyyy/MM/dd/HH").withZone(ZoneOffset.UTC)
 
   implicit class RichInstant(instant: Instant) {
     def prefixedTimePath(prefix: String): String =

--- a/src/test/scala/io/epiphanous/flinkrunner/util/InstantUtilsTest.scala
+++ b/src/test/scala/io/epiphanous/flinkrunner/util/InstantUtilsTest.scala
@@ -1,23 +1,22 @@
 package io.epiphanous.flinkrunner.util
 
 import io.epiphanous.flinkrunner.PropSpec
-
-import java.time.Instant
 import io.epiphanous.flinkrunner.util.InstantUtils.RichInstant
 
+import java.time.Instant
 
-class InstantUtilsTest extends PropSpec with StringUtils {
+class InstantUtilsTest extends PropSpec {
 
   property("Adds Prefix") {
-    val prefix = "prefix"
-    val zero_time         =  RichInstant(Instant.ofEpochSecond(0))
+    val prefix           = "prefix"
+    val zero_time        = RichInstant(Instant.ofEpochSecond(0))
     val formatted_string = "prefix/1970/01/01/00"
     zero_time.prefixedTimePath(prefix) shouldEqual formatted_string
   }
 
   property("does not need a prefix") {
-    val prefix = ""
-    val zero_time = RichInstant(Instant.ofEpochSecond(0))
+    val prefix           = ""
+    val zero_time        = RichInstant(Instant.ofEpochSecond(0))
     val formatted_string = "/1970/01/01/00"
     zero_time.prefixedTimePath(prefix) shouldEqual formatted_string
   }

--- a/src/test/scala/io/epiphanous/flinkrunner/util/InstantUtilsTest.scala
+++ b/src/test/scala/io/epiphanous/flinkrunner/util/InstantUtilsTest.scala
@@ -1,0 +1,25 @@
+package io.epiphanous.flinkrunner.util
+
+import io.epiphanous.flinkrunner.PropSpec
+
+import java.time.Instant
+import io.epiphanous.flinkrunner.util.InstantUtils.RichInstant
+
+
+class InstantUtilsTest extends PropSpec with StringUtils {
+
+  property("Adds Prefix") {
+    val prefix = "prefix"
+    val zero_time         =  RichInstant(Instant.ofEpochSecond(0))
+    val formatted_string = "prefix/1970/01/01/00"
+    zero_time.prefixedTimePath(prefix) shouldEqual formatted_string
+  }
+
+  property("does not need a prefix") {
+    val prefix = ""
+    val zero_time = RichInstant(Instant.ofEpochSecond(0))
+    val formatted_string = "/1970/01/01/00"
+    zero_time.prefixedTimePath(prefix) shouldEqual formatted_string
+  }
+
+}


### PR DESCRIPTION
Previously, this was throwing a `java.time.temporal.UnsupportedTemporalTypeException: Unsupported field: YearOfEra` error when attempting to materialize timestamps to a (S3) file sink