### PR TITLE
Dropping of tables due to JSON columns.

### DIFF
--- a/src/main/scala/io/epiphanous/flinkrunner/model/JdbcSinkColumn.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/JdbcSinkColumn.scala
@@ -50,7 +50,7 @@ case class JdbcSinkColumn(
     logger.debug(
       Seq(
         s"name:$name${eq(nameMatches)}$columnName",
-        s"type:${dataType.name}${eq(typeMatches)}$typeName",
+        s"type:${dataType.name}(value:${dataType.jdbcType})${eq(typeMatches)}$typeName(value:$jdbcType)",
         s"precision:${precision.map(_.toString).getOrElse("_")}${eq(precisionMatches)}$columnSize",
         s"scale:${scale.map(_.toString).getOrElse("_")}${eq(scaleMatches)}${if (Option(decimalDigits).isEmpty) "_"
           else decimalDigits.toString}",

--- a/src/main/scala/io/epiphanous/flinkrunner/model/SqlColumnType.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/SqlColumnType.scala
@@ -188,7 +188,7 @@ object SqlColumnType {
 
   final val JSON = SqlColumnType(
     "json",
-    Types.VARCHAR,
+    Types.OTHER,
     productConfig = Map(
       Mysql      -> withName("JSON", sharedDefaultConfig),
       Postgresql -> withName("JSONB", sharedDefaultConfig),


### PR DESCRIPTION
Table with a JSON type column was getting dropped due to mismatch of type.

JDBCSinkColumn -> def matches()

The type we were setting for json type was **Types.VARCHAR** (value = 12) but the value that was getting fetched was (value = 1111) i.e., **Types.OTHER**