### PR TITLE
Add test for $key change in FlinkEvent

### DIFF
--- a/src/test/scala/io/epiphanous/flinkrunner/model/FlinkEventSpec.scala
+++ b/src/test/scala/io/epiphanous/flinkrunner/model/FlinkEventSpec.scala
@@ -1,0 +1,19 @@
+package io.epiphanous.flinkrunner.model
+
+import io.epiphanous.flinkrunner.PropSpec
+class FlinkEventSpec extends PropSpec {
+
+  case class TestStringInterpolationEvent(id: String, timestamp: Long)
+      extends FlinkEvent {
+    override def $id        = id
+    override def $key       = id
+    override def $timestamp = timestamp
+  }
+
+  property("string interpolation") {
+    val event    = new TestStringInterpolationEvent("test_id", 0)
+    val bucketId = event.$bucketId
+    bucketId should include("test_id")
+    bucketId should not contain "$key"
+  }
+}


### PR DESCRIPTION
We're not doing string interpolation anymore but the test remains the same - check that the correct key is getting included in the bucketId instead of the name of the key.