### PR TITLE
support side-outputs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -97,7 +97,7 @@ val flinkDeps =
     // dropwizard metrics support
     "org.apache.flink"  % "flink-metrics-dropwizard"             % V.flink % Provided,
     // test support
-    "org.apache.flink"  % "flink-test-utils"                     % V.flink % Test,
+    "org.apache.flink"  % "flink-test-utils"                     % V.flink,
     "org.apache.flink"  % "flink-runtime-web"                    % V.flink % Test
   )
 
@@ -130,6 +130,7 @@ val otherDeps = Seq(
   "com.dimafeng"                    %% "testcontainers-scala-mysql"             % V.testContainersScala % Test,
   "com.dimafeng"                    %% "testcontainers-scala-postgresql"        % V.testContainersScala % Test,
   "com.dimafeng"                    %% "testcontainers-scala-scalatest"         % V.testContainersScala % Test,
+  "com.dimafeng"                    %% "testcontainers-scala-kafka"             % V.testContainersScala % Test,
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-csv"                 % V.jackson,
   "com.fasterxml.jackson.datatype"   % "jackson-datatype-jsr310"                % V.jackson,
   "com.fasterxml.jackson.module"    %% "jackson-module-scala"                   % V.jackson,

--- a/src/main/scala/io/epiphanous/flinkrunner/FlinkRunner.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/FlinkRunner.scala
@@ -52,6 +52,33 @@ abstract class FlinkRunner[ADT <: FlinkEvent: TypeInformation](
     classOf[AvroSchemaSerializer]
   )
 
+  val sourceNames: Seq[String] =
+    getSourceOrSinkNames("source")
+
+  val sinkNames: Seq[String] =
+    getSourceOrSinkNames("sink")
+
+  def defaultSourceName: String = sourceNames.headOption.getOrElse(
+    throw new RuntimeException("no sources are configured")
+  )
+
+  def defaultSinkName: String               = sinkNames.headOption.getOrElse(
+    throw new RuntimeException("no sinks are configured")
+  )
+  val sourceConfigs: Seq[SourceConfig[ADT]] =
+    sourceNames.map(name =>
+      SourceConfig[ADT](name, config, generatorFactoryOpt)
+    )
+
+  val sinkConfigs: Seq[SinkConfig[ADT]] =
+    sinkNames.map(name => SinkConfig[ADT](name, config))
+
+  val mainSinkConfigs: Seq[SinkConfig[ADT]] =
+    sinkConfigs.filterNot(_.isSideOutput)
+
+  val sideSinkConfigs: Seq[SinkConfig[ADT]] =
+    sinkConfigs.filter(_.isSideOutput)
+
   /** Gets (and returns as string) the execution plan for the job from the
     * StreamExecutionEnvironment.
     * @return
@@ -154,26 +181,15 @@ abstract class FlinkRunner[ADT <: FlinkEvent: TypeInformation](
       case sn if sn.nonEmpty => sn
       case _                 =>
         config
-          .getObject(s"${sourceOrSink}s")
-          .unwrapped()
-          .keySet()
-          .asScala
-          .toSeq
+          .getObjectOption(s"${sourceOrSink}s")
+          .map(
+            _.unwrapped()
+              .keySet()
+              .asScala
+              .toSeq
+          )
+          .getOrElse(Seq.empty)
     }).sorted
-
-  def getSourceNames: Seq[String] =
-    getSourceOrSinkNames("source")
-
-  def getSinkNames: Seq[String] =
-    getSourceOrSinkNames("sink")
-
-  def getDefaultSourceName: String = getSourceNames.headOption.getOrElse(
-    throw new RuntimeException("no sources are configured")
-  )
-
-  def getDefaultSinkName: String = getSinkNames.headOption.getOrElse(
-    throw new RuntimeException("no sinks are configured")
-  )
 
   /** Helper method to resolve the source configuration. Implementers can
     * override this method to customize source configuration behavior, in
@@ -185,8 +201,14 @@ abstract class FlinkRunner[ADT <: FlinkEvent: TypeInformation](
     *   SourceConfig
     */
   def getSourceConfig(
-      sourceName: String = getDefaultSourceName): SourceConfig[ADT] =
-    SourceConfig[ADT](sourceName, config, generatorFactoryOpt)
+      sourceName: String = defaultSourceName): SourceConfig[ADT] =
+    sourceConfigs
+      .find(_.name.equalsIgnoreCase(sourceName))
+      .getOrElse(
+        throw new RuntimeException(
+          s"unknown source <$sourceName> in job <${config.jobName}>"
+        )
+      )
 
   def _mockSource[E <: ADT: TypeInformation](
       sourceConfig: SourceConfig[ADT],
@@ -268,8 +290,15 @@ abstract class FlinkRunner[ADT <: FlinkEvent: TypeInformation](
   //  ********************** SINKS **********************
 
   def getSinkConfig(
-      sinkName: String = getDefaultSinkName): SinkConfig[ADT] =
-    SinkConfig[ADT](sinkName, config)
+      sinkName: String = defaultSinkName): SinkConfig[ADT] = {
+    sinkConfigs
+      .find(_.name.equalsIgnoreCase(sinkName))
+      .getOrElse(
+        throw new RuntimeException(
+          s"unknown sink <$sinkName> in job <${config.jobName}>"
+        )
+      )
+  }
 
   /** Usually, we should write to the sink, unless we have a non-empty
     * CheckResults configuration that determines otherwise.
@@ -294,7 +323,7 @@ abstract class FlinkRunner[ADT <: FlinkEvent: TypeInformation](
   def addRowSink[
       E <: ADT with EmbeddedRowType: TypeInformation: ru.TypeTag](
       stream: DataStream[E],
-      sinkName: String = getDefaultSinkName): Unit =
+      sinkName: String = defaultSinkName): Unit =
     getSinkConfig(sinkName).addRowSink[E](stream)
 
 }

--- a/src/main/scala/io/epiphanous/flinkrunner/flink/AvroStreamJob.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/flink/AvroStreamJob.scala
@@ -23,8 +23,8 @@ abstract class AvroStreamJob[
     ADT <: FlinkEvent: TypeInformation](runner: FlinkRunner[ADT])
     extends StreamJob[OUT, ADT](runner) {
 
-  override def sink(out: DataStream[OUT]): Unit =
-    runner.getSinkNames.foreach(name =>
-      runner.addAvroSink[OUT, A](out, name)
-    )
+  override def sink(out: DataStream[OUT]): Unit = {
+    runner.mainSinkConfigs.foreach(_.addAvroSink[OUT, A](out))
+    if (runner.sideSinkConfigs.nonEmpty) sinkSideOutputs(out)
+  }
 }

--- a/src/main/scala/io/epiphanous/flinkrunner/flink/TableStreamJob.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/flink/TableStreamJob.scala
@@ -20,6 +20,8 @@ abstract class TableStreamJob[
     ADT <: FlinkEvent: TypeInformation](runner: FlinkRunner[ADT])
     extends StreamJob[OUT, ADT](runner) {
 
-  override def sink(out: DataStream[OUT]): Unit =
-    runner.getSinkNames.foreach(name => runner.addRowSink[OUT](out, name))
+  override def sink(out: DataStream[OUT]): Unit = {
+    runner.mainSinkConfigs.foreach(_.addRowSink[OUT](out))
+    if (runner.sideSinkConfigs.nonEmpty) sinkSideOutputs(out)
+  }
 }

--- a/src/main/scala/io/epiphanous/flinkrunner/model/FlinkConnectorName.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/FlinkConnectorName.scala
@@ -37,8 +37,16 @@ object FlinkConnectorName extends Enum[FlinkConnectorName] {
 
   case object Print extends FlinkConnectorName
 
+  case object TestList extends FlinkConnectorName
+
   val sources: immutable.Seq[FlinkConnectorName] =
-    values diff IndexedSeq(Cassandra, Elasticsearch, Firehose, Print)
+    values diff IndexedSeq(
+      Cassandra,
+      Elasticsearch,
+      Firehose,
+      Print,
+      TestList
+    )
   val sinks: immutable.Seq[FlinkConnectorName]   =
     values diff IndexedSeq(Hybrid, Generator)
 

--- a/src/main/scala/io/epiphanous/flinkrunner/model/sink/SinkConfig.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/sink/SinkConfig.scala
@@ -6,7 +6,7 @@ import io.epiphanous.flinkrunner.util.RowUtils.rowTypeOf
 import org.apache.avro.generic.GenericRecord
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.scala.createTypeInformation
-import org.apache.flink.streaming.api.scala.DataStream
+import org.apache.flink.streaming.api.scala.{DataStream, OutputTag}
 import org.apache.flink.table.types.logical.RowType
 import org.apache.flink.types.Row
 
@@ -35,6 +35,12 @@ import scala.reflect.runtime.{universe => ru}
 trait SinkConfig[ADT <: FlinkEvent] extends SourceOrSinkConfig[ADT] {
 
   override val _sourceOrSink = "sink"
+
+  val isSideOutput: Boolean =
+    config.getBooleanOpt("side.output").getOrElse(false)
+
+  def getOutputTag[X <: ADT: TypeInformation]: OutputTag[X] =
+    OutputTag[X](name)
 
   def addSink[E <: ADT: TypeInformation](stream: DataStream[E]): Unit
 

--- a/src/main/scala/io/epiphanous/flinkrunner/model/sink/SinkConfig.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/sink/SinkConfig.scala
@@ -37,7 +37,7 @@ trait SinkConfig[ADT <: FlinkEvent] extends SourceOrSinkConfig[ADT] {
   override val _sourceOrSink = "sink"
 
   val isSideOutput: Boolean =
-    config.getBooleanOpt("side.output").getOrElse(false)
+    config.getBooleanOpt(pfx("side.output")).getOrElse(false)
 
   def getOutputTag[X <: ADT: TypeInformation]: OutputTag[X] =
     OutputTag[X](name)
@@ -91,6 +91,7 @@ object SinkConfig {
       case RabbitMQ      => RabbitMQSinkConfig(name, config)
       case Iceberg       => IcebergSinkConfig(name, config)
       case Print         => PrintSinkConfig(name, config)
+      case TestList      => TestListSinkConfig(name, config)
       case connector     =>
         throw new RuntimeException(
           s"Don't know how to configure ${connector.entryName} sink connector <$name> (in job <${config.jobName}>)"

--- a/src/main/scala/io/epiphanous/flinkrunner/model/sink/TestListSinkConfig.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/sink/TestListSinkConfig.scala
@@ -1,0 +1,47 @@
+package io.epiphanous.flinkrunner.model.sink
+
+import io.epiphanous.flinkrunner.model.FlinkConnectorName.TestList
+import io.epiphanous.flinkrunner.model.{EmbeddedAvroRecord, FlinkConfig, FlinkConnectorName, FlinkEvent}
+import org.apache.avro.generic.GenericRecord
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.streaming.api.scala.DataStream
+import org.apache.flink.test.streaming.runtime.util.TestListResultSink
+
+import scala.collection.JavaConverters._
+
+case class TestListSinkConfig[ADT <: FlinkEvent](
+    name: String,
+    config: FlinkConfig)
+    extends SinkConfig[ADT] {
+
+  override val connector: FlinkConnectorName = TestList
+
+  var testSink: Option[TestListResultSink[_ <: ADT]] = None
+
+  def getResults[E <: ADT]: List[E] =
+    testSink
+      .map(_.getResult.asScala.toList.asInstanceOf[List[E]])
+      .getOrElse(List.empty[E])
+
+  def getSortedResults[E <: ADT]: List[E] =
+    testSink
+      .map(_.getSortedResult.asScala.toList.asInstanceOf[List[E]])
+      .getOrElse(List.empty[E])
+
+  def __addSink[E <: ADT: TypeInformation](stream: DataStream[E]): Unit = {
+    val s = new TestListResultSink[E]
+    stream.addSink(s)
+    testSink = Some(s)
+    ()
+  }
+
+  override def addSink[E <: ADT: TypeInformation](
+      stream: DataStream[E]): Unit =
+    __addSink[E](stream)
+
+  override def addAvroSink[
+      E <: ADT with EmbeddedAvroRecord[A]: TypeInformation,
+      A <: GenericRecord: TypeInformation](stream: DataStream[E]): Unit =
+    __addSink[E](stream)
+
+}

--- a/src/test/scala/io/epiphanous/flinkrunner/flink/AvroStreamJobSpec.scala
+++ b/src/test/scala/io/epiphanous/flinkrunner/flink/AvroStreamJobSpec.scala
@@ -1,7 +1,7 @@
 package io.epiphanous.flinkrunner.flink
 
-import io.epiphanous.flinkrunner.model._
 import io.epiphanous.flinkrunner.PropSpec
+import io.epiphanous.flinkrunner.model._
 import io.epiphanous.flinkrunner.util.test.IdentityMap
 import org.apache.flink.streaming.api.scala._
 

--- a/src/test/scala/io/epiphanous/flinkrunner/flink/SideOutputSpec.scala
+++ b/src/test/scala/io/epiphanous/flinkrunner/flink/SideOutputSpec.scala
@@ -1,0 +1,76 @@
+package io.epiphanous.flinkrunner.flink
+
+import io.epiphanous.flinkrunner.model.sink.TestListSinkConfig
+import io.epiphanous.flinkrunner.model.{FlinkConfig, MySimpleADT, SimpleA}
+import io.epiphanous.flinkrunner.{FlinkRunner, PropSpec}
+import org.apache.flink.api.scala._
+
+class SideOutputSpec extends PropSpec {
+
+  property("side sink configs seen") {
+    getIdentityStreamJobRunner[
+      SimpleA,
+      MySimpleADT
+    ]().sideSinkConfigs.isEmpty shouldBe true
+    getIdentityStreamJobRunner[SimpleA, MySimpleADT](s"""
+         |jobs {
+         |  testJob {
+         |    sources { empty-sink {} }
+         |    sinks {
+         |      print-sink {}
+         |      side-print-sink { side.output = true }
+         |    }
+         |  }
+         |}
+         |""".stripMargin).sideSinkConfigs.size shouldBe 1
+    getIdentityStreamJobRunner[SimpleA, MySimpleADT](s"""
+         |jobs {
+         |  testJob {
+         |    sources { empty-sink {} }
+         |    sinks {
+         |      print-sink {}
+         |      first-side-print-sink { side.output = true }
+         |      second-side-print-sink { side.output = true }
+         |    }
+         |  }
+         |}
+         |""".stripMargin).sideSinkConfigs.size shouldBe 2
+  }
+
+  property("side sinks emit outputs") {
+    val config         = new FlinkConfig(
+      Array("testJob"),
+      Some(s"""
+         |execution.runtime-mode = batch
+         |jobs {
+         |  testJob {
+         |    sinks {
+         |      main-print-sink {}
+         |      side-test-list-sink {
+         |        side.output = true
+         |      }
+         |    }
+         |  }
+         |}
+         |""".stripMargin)
+    )
+    val input          = genPop[SimpleA](3).sorted
+    val runner         = new MyTestRunner(config, input)
+    runner.process()
+    val testSinkConfig = runner
+      .getSinkConfig("side-test-list-sink")
+      .asInstanceOf[TestListSinkConfig[MySimpleADT]]
+    val sideResults    = testSinkConfig.getSortedResults[SimpleA]
+    sideResults.zip(input).foreach { case (side, orig) =>
+      side.id shouldEqual s"side-${orig.id}"
+      side.a1 shouldEqual orig.a1 * 2
+    }
+  }
+
+}
+
+class MyTestRunner(config: FlinkConfig, input: Seq[SimpleA])
+    extends FlinkRunner[MySimpleADT](config) {
+  override def invoke(jobName: String): Unit =
+    new TestSideSinkJob(this, input).run()
+}

--- a/src/test/scala/io/epiphanous/flinkrunner/flink/TestSideSinkJob.scala
+++ b/src/test/scala/io/epiphanous/flinkrunner/flink/TestSideSinkJob.scala
@@ -1,0 +1,42 @@
+package io.epiphanous.flinkrunner.flink
+
+import io.epiphanous.flinkrunner.FlinkRunner
+import io.epiphanous.flinkrunner.model.sink.SinkConfig
+import io.epiphanous.flinkrunner.model.{MySimpleADT, SimpleA}
+import org.apache.flink.api.scala.createTypeInformation
+import org.apache.flink.streaming.api.functions.ProcessFunction
+import org.apache.flink.streaming.api.scala.{DataStream, OutputTag}
+import org.apache.flink.util.Collector
+
+class TestSideSinkJob(
+    runner: FlinkRunner[MySimpleADT],
+    input: Seq[SimpleA])
+    extends StreamJob[SimpleA, MySimpleADT](runner) {
+
+  val sideSinkConfig: SinkConfig[MySimpleADT] =
+    runner.getSinkConfig("side-test-list-sink")
+
+  val outputTag: OutputTag[SimpleA] = sideSinkConfig.getOutputTag[SimpleA]
+
+  override def transform: DataStream[SimpleA] =
+    runner.env
+      .fromCollection(input)
+      .process(new MyProcessFunction(outputTag))
+
+  override def sinkSideOutputs(out: DataStream[SimpleA]): Unit =
+    sideSinkConfig.addSink(out.getSideOutput(outputTag))
+}
+
+class MyProcessFunction(outputTag: OutputTag[SimpleA])
+    extends ProcessFunction[SimpleA, SimpleA] {
+  override def processElement(
+      element: SimpleA,
+      ctx: ProcessFunction[SimpleA, SimpleA]#Context,
+      out: Collector[SimpleA]): Unit = {
+    out.collect(element)
+    ctx.output(
+      outputTag,
+      element.copy(id = s"side-${element.id}", a1 = element.a1 * 2)
+    )
+  }
+}

--- a/src/test/scala/io/epiphanous/flinkrunner/model/MySimpleADT.scala
+++ b/src/test/scala/io/epiphanous/flinkrunner/model/MySimpleADT.scala
@@ -26,7 +26,8 @@ sealed trait MySimpleADT
 
 case class SimpleA(id: String, a0: String, a1: Int, ts: Instant)
     extends MySimpleADT
-    with EmbeddedRowType {
+    with EmbeddedRowType
+    with Ordered[SimpleA] {
   override def $id: String = id
 
   override def $key: String = a0
@@ -41,6 +42,8 @@ case class SimpleA(id: String, a0: String, a1: Int, ts: Instant)
     record.setField("ts", ts)
     record
   }
+
+  override def compare(that: SimpleA): Int = this.id.compare(that.id)
 }
 
 object SimpleA

--- a/src/test/scala/io/epiphanous/flinkrunner/model/sink/FirehoseSinkConfigSpec.scala
+++ b/src/test/scala/io/epiphanous/flinkrunner/model/sink/FirehoseSinkConfigSpec.scala
@@ -27,29 +27,27 @@ class FirehoseSinkConfigSpec extends PropSpec {
     )
 
   property("unconfigured firehose") {
-    val runner = testConfig("")
-    the[RuntimeException] thrownBy runner
-      .getSinkConfig() should have message "kinesis stream name required but missing in sink <firehose-sink> of job <testJob>"
+    the[RuntimeException] thrownBy testConfig(
+      ""
+    ) should have message "kinesis stream name required but missing in sink <firehose-sink> of job <testJob>"
   }
 
   property("minimal configuration") {
-    val runner = testConfig("stream = stream")
-    noException should be thrownBy runner.getSinkConfig()
+    noException should be thrownBy testConfig("stream = stream")
   }
 
   property("stream.name") {
-    val runner = testConfig("stream.name = stream")
-    noException should be thrownBy runner.getSinkConfig()
+    noException should be thrownBy testConfig("stream.name = stream")
   }
 
   property("delivery.stream") {
-    val runner = testConfig("delivery.stream = stream")
-    noException should be thrownBy runner.getSinkConfig()
+    noException should be thrownBy testConfig("delivery.stream = stream")
   }
 
   property("delivery.stream.name") {
-    val runner = testConfig("delivery.stream.name = stream")
-    noException should be thrownBy runner.getSinkConfig()
+    noException should be thrownBy testConfig(
+      "delivery.stream.name = stream"
+    )
   }
 
   def getProps(config: String = ""): KinesisProperties =


### PR DESCRIPTION
This PR adds a simple api to support the use of side outputs.

All `SinkConfigs` now have an `isSideOutput` flag (`side.output = true` in the job's sink config). And all `StreamJob` classes now have a `sinkSideOutputs()` method that will be called automatically if any sinks are configured with `side.output=true`. The method is unimplemented in `StreamJob` and must be implemented by the user's job class if any sinks are marked for side outputs. This method should use an implementation like the following:

```scala
class MyStreamJob[OUT <: ADT: TypeInformation, 
  ADT <: Event: TypeInformation](runner: FlinkRunner[ADT])
extends StreamJob[OUT, ADT] {

  val sideSinkConfig = runner.getSinkConfig("my-side-sink")
  val mySideOutputTag = sideSinkConfig.getOutputTag[MySideEvent]

  def transform: DataStream[OUT] = {
    // use a process function in here that creates a side output using the mySideOutputTag
  }

  override def sinkSideOutputs(out:DatatStream[OUT]): Unit = 
    sideSinkConfig.addSink[MySideEvent](out.getSideOutput(mySideOutputTag))
}

```
See the `SideOutputSpec` tests for an example of usage.