### PR TITLE
fix handling of properties in sources and sinks

### DIFF
--- a/src/main/scala/io/epiphanous/flinkrunner/model/sink/SinkConfig.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/sink/SinkConfig.scala
@@ -34,7 +34,7 @@ import scala.reflect.runtime.{universe => ru}
   */
 trait SinkConfig[ADT <: FlinkEvent] extends SourceOrSinkConfig[ADT] {
 
-  override val _sourceOrSink = "sink"
+  override def _sourceOrSink = "sink"
 
   def addSink[E <: ADT: TypeInformation](stream: DataStream[E]): Unit
 

--- a/src/main/scala/io/epiphanous/flinkrunner/model/source/KinesisSourceConfig.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/source/KinesisSourceConfig.scala
@@ -10,7 +10,10 @@ import io.epiphanous.flinkrunner.serde.JsonKinesisDeserializationSchema
 import io.epiphanous.flinkrunner.util.ConfigToProps.getFromEither
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.connector.source.{Source, SourceSplit}
-import org.apache.flink.kinesis.shaded.org.apache.flink.connector.aws.config.AWSConfigConstants.AWS_REGION
+import org.apache.flink.kinesis.shaded.org.apache.flink.connector.aws.config.AWSConfigConstants.{
+  AWS_ENDPOINT,
+  AWS_REGION
+}
 import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.connectors.kinesis.FlinkKinesisConsumer
 import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants._
@@ -56,6 +59,8 @@ import scala.util.Try
   *   - `efo.consumer`: name of the efo consumer (defaults to
   *     `jobName`.`sourceName`)
   *   - `aws.region`: AWS region of your kinesis endpoint
+  *   - `aws.endpoint`: AWS endpoint for kinesis (usually only required for
+  *     localstack)
   *   - `config`: optional config to pass to kinesis client (see
   *     [[org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants]])
   *
@@ -78,6 +83,12 @@ case class KinesisSourceConfig[ADT <: FlinkEvent](
       Regions.US_EAST_1.name()
     )
   properties.setProperty(AWS_REGION, awsRegion)
+
+  val awsEndpoint: Option[String] =
+    getFromEither(pfx(), Seq(AWS_ENDPOINT), config.getStringOpt)
+  awsEndpoint.foreach(endpoint =>
+    properties.setProperty(AWS_ENDPOINT, endpoint)
+  )
 
   val streams: List[String] = {
 

--- a/src/main/scala/io/epiphanous/flinkrunner/model/source/SourceConfig.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/source/SourceConfig.scala
@@ -48,7 +48,7 @@ import scala.util.Try
   */
 trait SourceConfig[ADT <: FlinkEvent] extends SourceOrSinkConfig[ADT] {
 
-  override val _sourceOrSink = "source"
+  override def _sourceOrSink = "source"
 
   val watermarkStrategy: String =
     Try(config.getString(pfx("watermark.strategy")))

--- a/src/test/scala/io/epiphanous/flinkrunner/model/source/KinesisSourceConfigSpec.scala
+++ b/src/test/scala/io/epiphanous/flinkrunner/model/source/KinesisSourceConfigSpec.scala
@@ -175,4 +175,29 @@ class KinesisSourceConfigSpec extends PropSpec {
     the[Exception] thrownBy noProvidedConfig should have message "Kinesis source kinesis-test is missing required 'stream' or 'streams' property"
   }
 
+  property("endpoint property") {
+    val endpointConfig =
+      """
+        |aws.endpoint = "http://localhost:4567"
+        |""".stripMargin
+    defaultConfigPlus(endpointConfig).awsEndpoint shouldBe Some(
+      "http://localhost:4567"
+    )
+  }
+
+  property("config.endpoint property") {
+    val endpointConfig =
+      """
+        |config {
+        |  aws.endpoint = "http://localhost:4567"
+        |}
+        |""".stripMargin
+    val sinkConfig     = defaultConfigPlus(endpointConfig)
+    sinkConfig.properties.getProperty(
+      "aws.endpoint"
+    ) shouldBe "http://localhost:4567"
+    sinkConfig.awsEndpoint shouldBe Some(
+      "http://localhost:4567"
+    )
+  }
 }


### PR DESCRIPTION
The `properties` field of `SourceConfig` (and `SinkConfig`) is not properly initialized because the `SourceOrSink._sourceOrSink` method is called before it is initialized due to the way `_sourceOrSink` is overridden in `SourceConfig` and `SinkConfig` (as a `val` and not a `def`).

The result of this is that unless we explicitly write code in a sink or source config class to get a specific property from the config and add it to the the source or sink's `properties` field, it won't show up in the `properties` field.

This fix handles that problem generally across all sources and sinks. And it also, in the case of `KinesisSourceConfig`, handles the `aws.endpoint` config explicitly.