### PR TITLE
add identity jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ scala:
 dist: bionic
 
 jdk:
-  - oraclejdk11
   - openjdk11
 
 stages:

--- a/build.sbt
+++ b/build.sbt
@@ -29,34 +29,43 @@ resolvers += "Local Maven Repository" at "file://" + Path.userHome.absolutePath 
 resolvers += "Confluent Repository" at "https://packages.confluent.io/maven/"
 
 val V = new {
-  val flink               = "1.17.1"
-  val flinkMinor          = "1.17"
-  val logback             = "1.4.6"
-  val scalaLogging        = "3.9.5"
-  val scalaTest           = "3.2.15"
-  val scalaTestPlus       = "3.2.15.0"
-  val scalaCheck          = "1.17.0"
-  val testContainersScala = "0.40.12"
-  val jackson             = "2.14.2"
-  val circe               = "0.14.2"
-  val http4s              = "0.23.12"
-  val enumeratum          = "1.7.2"
-  val typesafeConfig      = "1.4.2"
-  val guava               = "31.1-jre"
-  val squants             = "1.8.3"
-  val confluentAvroSerde  = "7.1.1"
-  val parquet             = "1.12.3"
-  val awsSdk              = "1.12.429"
-  val jdbcMysql           = "8.0.32"
-  val jdbcPg              = "42.5.4"
-  val jdbcMssql           = "11.2.0.jre11"
-  val hadoop              = "3.3.2"
-  val cassandraDriver     = "3.11.3"
-  val uuidCreator         = "5.2.0"
-  val iceberg             = "1.3.0"
-  val jna                 = "5.12.1" // needed for testcontainers in some jvms
-  val awsSdk2             = "2.20.26"
-  val dropWizard          = "4.2.17"
+  val flink                  = "1.17.1"
+  val flinkMinor             = "1.17"
+  val fcKinesis              = s"4.1.0-$flinkMinor"
+  val fcKafka                = s"3.0.0-$flinkMinor"
+  val fcCassandra            = s"3.1.0-$flinkMinor"
+  val fcJdbc                 = s"3.1.0-$flinkMinor"
+  val fcRabbitMq             = s"3.0.1-$flinkMinor"
+  val fcElastic              = s"3.0.1-$flinkMinor"
+  // -------------------------------------------------
+  val awsSdk                 = "1.12.472"
+  val awsSdk2                = "2.20.69"
+  val cassandraDriver        = "3.11.3"
+  val circe                  = "0.14.2"
+  val confluentAvroSerde     = "7.1.1"
+  val dropWizard             = "4.2.17"
+  val enumeratum             = "1.7.2"
+  val guava                  = "31.1-jre"
+  val hadoop                 = "3.3.2"
+  val http4s                 = "0.23.12"
+  val iceberg                = "1.3.0"
+  val jackson                = "2.14.2"
+  val jacksonScalaReflectExt = "2.15.0"
+  val jdbcMssql              = "11.2.0.jre11"
+  val jdbcMysql              = "8.0.33"
+  val jdbcPg                 = "42.5.4"
+  val jna                    = "5.12.1" // needed for testcontainers in some jvms
+  val logback                = "1.4.7"
+  val parquet                = "1.13.1"
+  val requests               = "0.8.0"
+  val scalaCheck             = "1.17.0"
+  val scalaLogging           = "3.9.5"
+  val scalaTest              = "3.2.15"
+  val scalaTestPlus          = "3.2.16.0"
+  val squants                = "1.8.3"
+  val testContainersScala    = "0.40.12"
+  val typesafeConfig         = "1.4.2"
+  val uuidCreator            = "5.2.0"
 }
 
 val flinkDeps =
@@ -69,36 +78,36 @@ val flinkDeps =
     // sql parser
     "org.apache.flink"  % "flink-sql-parser"                     % V.flink,
     // queryable state
-    "org.apache.flink"  % "flink-queryable-state-runtime"        % V.flink      % Provided,
+    "org.apache.flink"  % "flink-queryable-state-runtime"        % V.flink       % Provided,
     // complex event processing
-    "org.apache.flink"  % "flink-cep"                            % V.flink      % Provided,
+    "org.apache.flink"  % "flink-cep"                            % V.flink       % Provided,
     // connectors
-    "org.apache.flink"  % "flink-connector-base"                 % V.flink      % Provided, // ds hybrid source
-    "org.apache.flink"  % "flink-connector-files"                % V.flink      % Provided, // ds text files
-    "org.apache.flink"  % "flink-parquet"                        % V.flink      % Provided, // parquet bulk sink
-    "org.apache.flink"  % "flink-connector-kafka"                % V.flink      % Provided,
-    "org.apache.flink"  % "flink-connector-kinesis"              % s"4.1.0-${V.flinkMinor}" % Provided,
-    "org.apache.flink"  % "flink-connector-aws-kinesis-streams"  % s"4.1.0-${V.flinkMinor}" % Provided,
-    "org.apache.flink"  % "flink-connector-aws-kinesis-firehose" % s"4.1.0-${V.flinkMinor}" % Provided,
-    "org.apache.flink" %% "flink-connector-cassandra"            % s"3.1.0-${V.flinkMinor}" % Provided,
-    "org.apache.flink"  % "flink-connector-elasticsearch7"       % s"3.0.1-${V.flinkMinor}" % Provided,
-    "org.apache.flink"  % "flink-connector-jdbc"                 % s"3.1.0-${V.flinkMinor}" % Provided,
-    "org.apache.flink"  % "flink-connector-rabbitmq"             % s"3.0.1-${V.flinkMinor}" % Provided,
+    "org.apache.flink"  % "flink-connector-base"                 % V.flink       % Provided, // ds hybrid source
+    "org.apache.flink"  % "flink-connector-files"                % V.flink       % Provided, // ds text files
+    "org.apache.flink"  % "flink-parquet"                        % V.flink       % Provided, // parquet bulk sink
+    "org.apache.flink"  % "flink-connector-kafka"                % V.fcKafka     % Provided,
+    "org.apache.flink"  % "flink-connector-kinesis"              % V.fcKinesis   % Provided,
+    "org.apache.flink"  % "flink-connector-aws-kinesis-streams"  % V.fcKinesis   % Provided,
+    "org.apache.flink"  % "flink-connector-aws-kinesis-firehose" % V.fcKinesis   % Provided,
+    "org.apache.flink" %% "flink-connector-cassandra"            % V.fcCassandra % Provided,
+    "org.apache.flink"  % "flink-connector-elasticsearch7"       % V.fcElastic   % Provided,
+    "org.apache.flink"  % "flink-connector-jdbc"                 % V.fcJdbc      % Provided,
+    "org.apache.flink"  % "flink-connector-rabbitmq"             % V.fcRabbitMq  % Provided,
     // avro support
-    "org.apache.flink"  % "flink-avro"                           % V.flink      % Provided, // ds and table avro format
-    "org.apache.flink"  % "flink-avro-confluent-registry"        % V.flink      % Provided, // ds and table avro registry format
+    "org.apache.flink"  % "flink-avro"                           % V.flink       % Provided, // ds and table avro format
+    "org.apache.flink"  % "flink-avro-confluent-registry"        % V.flink       % Provided, // ds and table avro registry format
     // table api support
     "org.apache.flink" %% "flink-table-api-scala-bridge"         % V.flink, // table api scala
-    "org.apache.flink"  % "flink-table-planner-loader"           % V.flink      % Provided, // table api
-    "org.apache.flink"  % "flink-table-runtime"                  % V.flink      % Provided, // table runtime
-    "org.apache.flink"  % "flink-csv"                            % V.flink      % Provided, // table api csv format
-    "org.apache.flink"  % "flink-json"                           % V.flink      % Provided, // table api json format
+    "org.apache.flink"  % "flink-table-planner-loader"           % V.flink       % Provided, // table api
+    "org.apache.flink"  % "flink-table-runtime"                  % V.flink       % Provided, // table runtime
+    "org.apache.flink"  % "flink-csv"                            % V.flink       % Provided, // table api csv format
+    "org.apache.flink"  % "flink-json"                           % V.flink       % Provided, // table api json format
     "org.apache.flink"  % "flink-clients"                        % V.flink,
     // dropwizard metrics support
-    "org.apache.flink"  % "flink-metrics-dropwizard"             % V.flink      % Provided,
+    "org.apache.flink"  % "flink-metrics-dropwizard"             % V.flink       % Provided,
     // test support
-    "org.apache.flink"  % "flink-test-utils"                     % V.flink      % Test,
-    "org.apache.flink"  % "flink-runtime-web"                    % V.flink      % Test
+    "org.apache.flink"  % "flink-test-utils"                     % V.flink       % Test,
+    "org.apache.flink"  % "flink-runtime-web"                    % V.flink       % Test
   )
 
 val loggingDeps = Seq(
@@ -134,9 +143,9 @@ val otherDeps = Seq(
   "com.fasterxml.jackson.datatype"   % "jackson-datatype-jsr310"                % V.jackson,
   "com.fasterxml.jackson.module"    %% "jackson-module-scala"                   % V.jackson,
   "com.github.f4b6a3"                % "uuid-creator"                           % V.uuidCreator,
-  "com.github.pjfanning"            %% "jackson-scala-reflect-extensions"       % "2.14.0",
+  "com.github.pjfanning"            %% "jackson-scala-reflect-extensions"       % V.jacksonScalaReflectExt,
   "com.google.guava"                 % "guava"                                  % V.guava,
-  "com.lihaoyi"                     %% "requests"                               % "0.8.0"               % Test,
+  "com.lihaoyi"                     %% "requests"                               % V.requests            % Test,
   "com.microsoft.sqlserver"          % "mssql-jdbc"                             % V.jdbcMssql           % Provided,
   "com.typesafe"                     % "config"                                 % V.typesafeConfig,
   "io.confluent"                     % "kafka-avro-serializer"                  % V.confluentAvroSerde  % Provided,

--- a/src/main/scala/io/epiphanous/flinkrunner/flink/AvroIdentityJob.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/flink/AvroIdentityJob.scala
@@ -1,0 +1,20 @@
+package io.epiphanous.flinkrunner.flink
+
+import io.epiphanous.flinkrunner.FlinkRunner
+import io.epiphanous.flinkrunner.model.{
+  EmbeddedAvroRecord,
+  EmbeddedAvroRecordInfo,
+  FlinkEvent
+}
+import org.apache.avro.generic.GenericRecord
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.streaming.api.scala.DataStream
+
+class AvroIdentityJob[
+    E <: ADT with EmbeddedAvroRecord[A]: TypeInformation,
+    A <: GenericRecord: TypeInformation,
+    ADT <: FlinkEvent: TypeInformation](runner: FlinkRunner[ADT])(implicit
+    fromKV: EmbeddedAvroRecordInfo[A] => E)
+    extends AvroStreamJob[E, A, ADT](runner) {
+  override def transform: DataStream[E] = singleAvroSource[E, A]()
+}

--- a/src/main/scala/io/epiphanous/flinkrunner/flink/AvroTableIdentityJob.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/flink/AvroTableIdentityJob.scala
@@ -10,8 +10,10 @@ import org.apache.avro.generic.GenericRecord
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.scala.DataStream
 
+import scala.reflect.runtime.{universe => ru}
+
 class AvroTableIdentityJob[
-    E <: ADT with EmbeddedAvroRecord[A]: TypeInformation,
+    E <: ADT with EmbeddedAvroRecord[A]: TypeInformation: ru.TypeTag,
     A <: GenericRecord: TypeInformation,
     ADT <: FlinkEvent: TypeInformation](runner: FlinkRunner[ADT])(implicit
     fromKV: EmbeddedAvroRecordInfo[A] => E)

--- a/src/main/scala/io/epiphanous/flinkrunner/flink/AvroTableIdentityJob.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/flink/AvroTableIdentityJob.scala
@@ -1,0 +1,20 @@
+package io.epiphanous.flinkrunner.flink
+
+import io.epiphanous.flinkrunner.FlinkRunner
+import io.epiphanous.flinkrunner.model.{
+  EmbeddedAvroRecord,
+  EmbeddedAvroRecordInfo,
+  FlinkEvent
+}
+import org.apache.avro.generic.GenericRecord
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.streaming.api.scala.DataStream
+
+class AvroTableIdentityJob[
+    E <: ADT with EmbeddedAvroRecord[A]: TypeInformation,
+    A <: GenericRecord: TypeInformation,
+    ADT <: FlinkEvent: TypeInformation](runner: FlinkRunner[ADT])(implicit
+    fromKV: EmbeddedAvroRecordInfo[A] => E)
+    extends TableStreamJob[E, ADT](runner) {
+  override def transform: DataStream[E] = singleAvroSource[E, A]()
+}

--- a/src/main/scala/io/epiphanous/flinkrunner/flink/IdentityJob.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/flink/IdentityJob.scala
@@ -1,0 +1,13 @@
+package io.epiphanous.flinkrunner.flink
+
+import io.epiphanous.flinkrunner.FlinkRunner
+import io.epiphanous.flinkrunner.model.FlinkEvent
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.streaming.api.scala.DataStream
+
+class IdentityJob[
+    E <: ADT: TypeInformation,
+    ADT <: FlinkEvent: TypeInformation](runner: FlinkRunner[ADT])
+    extends StreamJob[E, ADT](runner) {
+  override def transform: DataStream[E] = singleSource[E]()
+}

--- a/src/main/scala/io/epiphanous/flinkrunner/flink/TableIdentityJob.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/flink/TableIdentityJob.scala
@@ -1,0 +1,13 @@
+package io.epiphanous.flinkrunner.flink
+
+import io.epiphanous.flinkrunner.FlinkRunner
+import io.epiphanous.flinkrunner.model.{EmbeddedRowType, FlinkEvent}
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.streaming.api.scala.DataStream
+
+class TableIdentityJob[
+    E <: ADT with EmbeddedRowType: TypeInformation,
+    ADT <: FlinkEvent: TypeInformation](runner: FlinkRunner[ADT])
+    extends TableStreamJob[E, ADT](runner) {
+  override def transform: DataStream[E] = singleSource[E]()
+}

--- a/src/main/scala/io/epiphanous/flinkrunner/flink/TableIdentityJob.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/flink/TableIdentityJob.scala
@@ -5,8 +5,10 @@ import io.epiphanous.flinkrunner.model.{EmbeddedRowType, FlinkEvent}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.scala.DataStream
 
+import scala.reflect.runtime.{universe => ru}
+
 class TableIdentityJob[
-    E <: ADT with EmbeddedRowType: TypeInformation,
+    E <: ADT with EmbeddedRowType: TypeInformation: ru.TypeTag,
     ADT <: FlinkEvent: TypeInformation](runner: FlinkRunner[ADT])
     extends TableStreamJob[E, ADT](runner) {
   override def transform: DataStream[E] = singleSource[E]()

--- a/src/test/scala/io/epiphanous/flinkrunner/flink/AvroIdentityJobSpec.scala
+++ b/src/test/scala/io/epiphanous/flinkrunner/flink/AvroIdentityJobSpec.scala
@@ -1,0 +1,24 @@
+package io.epiphanous.flinkrunner.flink
+
+import io.epiphanous.flinkrunner.model.{ARecord, AWrapper, MyAvroADT}
+import io.epiphanous.flinkrunner.{FlinkRunner, PropSpec}
+import org.apache.flink.api.scala.createTypeInformation
+
+class AvroIdentityJobSpec extends PropSpec {
+  property("job works") {
+    val input = genPop[AWrapper]()
+    new FlinkRunner[MyAvroADT](
+      getDefaultConfig,
+      Some(
+        getCheckResults[AWrapper, AWrapper, MyAvroADT](
+          "job works",
+          results => results shouldEqual input,
+          input
+        )
+      )
+    ) {
+      override def invoke(jobName: String): Unit =
+        new AvroIdentityJob[AWrapper, ARecord, MyAvroADT](this).run()
+    }.process()
+  }
+}

--- a/src/test/scala/io/epiphanous/flinkrunner/flink/AvroStreamJobSpec.scala
+++ b/src/test/scala/io/epiphanous/flinkrunner/flink/AvroStreamJobSpec.scala
@@ -1,7 +1,7 @@
 package io.epiphanous.flinkrunner.flink
 
-import io.epiphanous.flinkrunner.model._
 import io.epiphanous.flinkrunner.PropSpec
+import io.epiphanous.flinkrunner.model._
 import io.epiphanous.flinkrunner.util.test.IdentityMap
 import org.apache.flink.streaming.api.scala._
 

--- a/src/test/scala/io/epiphanous/flinkrunner/flink/AvroTableIdentityJobSpec.scala
+++ b/src/test/scala/io/epiphanous/flinkrunner/flink/AvroTableIdentityJobSpec.scala
@@ -1,0 +1,26 @@
+package io.epiphanous.flinkrunner.flink
+
+import io.epiphanous.flinkrunner.model.{BRecord, BWrapper, MyAvroADT}
+import io.epiphanous.flinkrunner.{FlinkRunner, PropSpec}
+import org.apache.flink.api.scala.createTypeInformation
+
+class AvroTableIdentityJobSpec extends PropSpec {
+
+  property("job works") {
+    val input = genPop[BWrapper]()
+    new FlinkRunner[MyAvroADT](
+      getDefaultConfig,
+      Some(
+        getCheckResults[BWrapper, BWrapper, MyAvroADT](
+          "job works",
+          results => results shouldEqual input,
+          input
+        )
+      )
+    ) {
+      override def invoke(jobName: String): Unit =
+        new AvroTableIdentityJob[BWrapper, BRecord, MyAvroADT](this).run()
+    }.process()
+  }
+
+}

--- a/src/test/scala/io/epiphanous/flinkrunner/flink/IdentityJobSpec.scala
+++ b/src/test/scala/io/epiphanous/flinkrunner/flink/IdentityJobSpec.scala
@@ -1,0 +1,25 @@
+package io.epiphanous.flinkrunner.flink
+
+import io.epiphanous.flinkrunner.model.{MySimpleADT, SimpleA}
+import io.epiphanous.flinkrunner.{FlinkRunner, PropSpec}
+import org.apache.flink.api.scala.createTypeInformation
+
+class IdentityJobSpec extends PropSpec {
+
+  property("job works") {
+    val input = genPop[SimpleA]()
+    new FlinkRunner[MySimpleADT](
+      getDefaultConfig,
+      Some(
+        getCheckResults[SimpleA, SimpleA, MySimpleADT](
+          "job works",
+          results => results shouldEqual input,
+          input
+        )
+      )
+    ) {
+      override def invoke(jobName: String): Unit =
+        new TableIdentityJob[SimpleA, MySimpleADT](this).run()
+    }.process()
+  }
+}

--- a/src/test/scala/io/epiphanous/flinkrunner/flink/TableIdentityJobSpec.scala
+++ b/src/test/scala/io/epiphanous/flinkrunner/flink/TableIdentityJobSpec.scala
@@ -1,0 +1,25 @@
+package io.epiphanous.flinkrunner.flink
+
+import io.epiphanous.flinkrunner.model.{MySimpleADT, SimpleA}
+import io.epiphanous.flinkrunner.{FlinkRunner, PropSpec}
+import org.apache.flink.api.scala.createTypeInformation
+
+class TableIdentityJobSpec extends PropSpec {
+
+  property("job works") {
+    val input = genPop[SimpleA]()
+    new FlinkRunner[MySimpleADT](
+      getDefaultConfig,
+      Some(
+        getCheckResults[SimpleA, SimpleA, MySimpleADT](
+          "job works",
+          results => results shouldEqual input,
+          input
+        )
+      )
+    ) {
+      override def invoke(jobName: String): Unit =
+        new TableIdentityJob[SimpleA, MySimpleADT](this).run()
+    }.process()
+  }
+}


### PR DESCRIPTION
Add basic identity job classes. These simply copy their input to their output unchanged and are best used for materializing inputs streams to other sinks.

- `IdentityJob` - Based on `StreamJob`, for non-avro inputs writing to non-avro sinks
- `TableIdentityJob` - Based on `TableStreamJob`, for non-avro inputs writing to table sinks
- `AvroIdentityJob` - Based on AvroStreamJob, for avro inputs writing to avro sinks
- `AvroTableIdentityJob` - Based on `TableStreamJob`, for avro inputs writing to table sinks

You obviously can override these for other scenarios, but in that case, its not really worth using these classes because they are just boilerplate and you might as well use the underlying base classes.

This PR also 
- adds `getDefaultConfig` and `getCheckResults` methods to `FlinkRunnerSpec` to make writing tests a little easier
- remove OracleJDK from travis config to improve travis runs
- updates `build.sbt` to latest libraries