### PR TITLE
turn down logging when deserializing tombstone records

### DIFF
--- a/src/main/scala/io/epiphanous/flinkrunner/serde/AvroRegistryKafkaRecordDeserializationSchema.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/serde/AvroRegistryKafkaRecordDeserializationSchema.scala
@@ -66,7 +66,7 @@ abstract class AvroRegistryKafkaRecordDeserializationSchema[
 
     // shortcut process if record value is tombstone
     if (Option(record.value()).isEmpty) {
-      logger.info(s"ignoring null value kafka record ($recordInfo)")
+      logger.trace(s"ignoring null value kafka record ($recordInfo)")
       return
     }
 

--- a/src/test/scala/io/epiphanous/flinkrunner/serde/AvroRegistryKafkaRecordDeserializationSchemaSpec.scala
+++ b/src/test/scala/io/epiphanous/flinkrunner/serde/AvroRegistryKafkaRecordDeserializationSchemaSpec.scala
@@ -23,7 +23,7 @@ class AvroRegistryKafkaRecordDeserializationSchemaSpec
     with MockitoSugar {
 
   val mockLogger: UnderlyingLogger = mock[UnderlyingLogger]
-  when(mockLogger.isInfoEnabled).thenReturn(true)
+  when(mockLogger.isTraceEnabled).thenReturn(true)
   when(mockLogger.isErrorEnabled).thenReturn(true)
 
   val topic      = "topic"
@@ -74,7 +74,7 @@ class AvroRegistryKafkaRecordDeserializationSchemaSpec
       emptyDeserializer.deserialize(getConsumerRecord(), out)
     ) should be a 'success
     collected should have length 0
-    verify(mockLogger).info(
+    verify(mockLogger).trace(
       s"ignoring null value kafka record ({})",
       recordInfo
     )


### PR DESCRIPTION
Reduce log level to TRACE when ignoring tombstone records in the avro deserializer.