### PR TITLE
add trait to assign kafka headers into EmbeddedAvroRecords

### DIFF
--- a/src/main/scala/io/epiphanous/flinkrunner/model/AssignKafkaHeaders.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/AssignKafkaHeaders.scala
@@ -3,12 +3,21 @@ package io.epiphanous.flinkrunner.model
 import org.apache.avro.generic.GenericRecord
 
 trait AssignKafkaHeaders[A <: GenericRecord] {
-  this: FlinkEvent with EmbeddedAvroRecord[A] =>
+  this: {
+    val $record: A
+    val $recordHeaders: Map[String, String]
+  } =>
 
-  def assignHeaders: Seq[KafkaHeaderMapper] =
+  val defaultAssignableHeaders: Seq[KafkaHeaderMapper] =
     KafkaInfoHeader.values.map(KafkaHeaderMapper.apply)
 
+  def customAssignableHeaders: Seq[KafkaHeaderMapper] = Seq.empty
+
   def assignKafkaHeaders(): Unit =
-    assignHeaders.foreach(_.assign($record, $recordHeaders))
+    (defaultAssignableHeaders ++ customAssignableHeaders).foreach(
+      _.assign($record, $recordHeaders)
+    )
+
+  assignKafkaHeaders()
 
 }

--- a/src/main/scala/io/epiphanous/flinkrunner/model/AssignKafkaHeaders.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/AssignKafkaHeaders.scala
@@ -1,0 +1,14 @@
+package io.epiphanous.flinkrunner.model
+
+import org.apache.avro.generic.GenericRecord
+
+trait AssignKafkaHeaders[A <: GenericRecord] {
+  this: FlinkEvent with EmbeddedAvroRecord[A] =>
+
+  def assignHeaders: Seq[KafkaHeaderMapper] =
+    KafkaInfoHeader.values.map(KafkaHeaderMapper.apply)
+
+  def assignKafkaHeaders(): Unit =
+    assignHeaders.foreach(_.assign($record, $recordHeaders))
+
+}

--- a/src/main/scala/io/epiphanous/flinkrunner/model/KafkaHeaderMapper.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/KafkaHeaderMapper.scala
@@ -1,0 +1,28 @@
+package io.epiphanous.flinkrunner.model
+
+import KafkaInfoHeader.{headerFieldName, headerName, headerValueMapper}
+import org.apache.avro.generic.GenericRecord
+
+case class KafkaHeaderMapper(
+    headerName: String,
+    recordField: String,
+    mapper: String => Option[Any]) {
+  def assign[A <: GenericRecord](
+      record: A,
+      headers: Map[String, String]): Unit =
+    if (record.hasField(recordField))
+      headers
+        .get(headerName)
+        .foreach(headerValue =>
+          record.put(recordField, mapper(headerValue).orNull)
+        )
+}
+
+object KafkaHeaderMapper {
+  def apply(header: KafkaInfoHeader): KafkaHeaderMapper =
+    KafkaHeaderMapper(
+      headerName(header),
+      headerFieldName(header),
+      headerValueMapper(header)
+    )
+}

--- a/src/main/scala/io/epiphanous/flinkrunner/model/KafkaHeaderMapper.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/KafkaHeaderMapper.scala
@@ -3,6 +3,9 @@ package io.epiphanous.flinkrunner.model
 import KafkaInfoHeader.{headerFieldName, headerName, headerValueMapper}
 import org.apache.avro.generic.GenericRecord
 
+import java.time.Instant
+import scala.util.Try
+
 case class KafkaHeaderMapper(
     headerName: String,
     recordField: String,
@@ -25,4 +28,13 @@ object KafkaHeaderMapper {
       headerFieldName(header),
       headerValueMapper(header)
     )
+
+  def intMapper(value: String): Option[Int]       = Try(value.toInt).toOption
+  def stringMapper(value: String): Option[String] = Option(value)
+
+  def longMapper(value: String): Option[Long]       = Try(value.toLong).toOption
+  def booleanMapper(value: String): Option[Boolean] = Try(
+    value.toBoolean
+  ).toOption
+
 }

--- a/src/main/scala/io/epiphanous/flinkrunner/model/KafkaInfoHeader.scala
+++ b/src/main/scala/io/epiphanous/flinkrunner/model/KafkaInfoHeader.scala
@@ -1,6 +1,5 @@
 package io.epiphanous.flinkrunner.model
 
-import enumeratum.EnumEntry.Snakecase
 import enumeratum._
 import io.epiphanous.flinkrunner.util.RichString.RichString
 
@@ -8,7 +7,7 @@ import java.time.Instant
 import scala.collection.immutable
 import scala.util.Try
 
-sealed trait KafkaInfoHeader extends EnumEntry with Snakecase
+sealed trait KafkaInfoHeader extends EnumEntry
 
 object KafkaInfoHeader extends Enum[KafkaInfoHeader] {
 

--- a/src/test/avro/RecordWithHeaders.avsc
+++ b/src/test/avro/RecordWithHeaders.avsc
@@ -1,0 +1,45 @@
+{
+  "name": "RecordWithHeaders",
+  "namespace": "io.epiphanous.flinkrunner.model",
+  "type": "record",
+  "fields": [
+    {
+      "name": "a",
+      "type": "string"
+    },
+    {
+      "name": "b",
+      "type": "int"
+    },
+    {
+      "name": "kafka_offset",
+      "type": ["null","long"],
+      "default": null
+    },
+    {
+      "name": "kafka_partition",
+      "type": ["null","int"],
+      "default": null
+    },
+    {
+      "name": "kafka_topic",
+      "type": ["null","string"],
+      "default": null
+    },
+    {
+      "name": "myIntHeader",
+      "type": ["null","int"],
+      "default": null
+    },
+    {
+      "name": "myStringHeader",
+      "type": ["null","string"],
+      "default": null
+    },
+    {
+      "name": "myBooleanHeader",
+      "type": ["null","boolean"],
+      "default": null
+    }
+  ]
+}

--- a/src/test/avro/RecordWithHeaders.avsc
+++ b/src/test/avro/RecordWithHeaders.avsc
@@ -40,6 +40,17 @@
       "name": "myBooleanHeader",
       "type": ["null","boolean"],
       "default": null
+    },
+    {
+      "name": "myTimestampHeader",
+      "type": [
+        "null",
+        {
+          "type": "long",
+          "logicalType": "timestamp-millis"
+        }
+      ],
+      "default": null
     }
   ]
 }

--- a/src/test/scala/io/epiphanous/flinkrunner/model/AssignKafkaHeadersSpec.scala
+++ b/src/test/scala/io/epiphanous/flinkrunner/model/AssignKafkaHeadersSpec.scala
@@ -1,0 +1,67 @@
+package io.epiphanous.flinkrunner.model
+
+import io.epiphanous.flinkrunner.PropSpec
+import org.apache.avro.generic.GenericRecord
+
+import java.util.UUID
+
+class AssignKafkaHeadersSpec extends PropSpec {
+
+  case class MyEventWithHeaderFields[A <: GenericRecord](
+      $record: A,
+      override val $recordHeaders: Map[String, String] = Map.empty,
+      override val customAssignableHeaders: Seq[KafkaHeaderMapper] =
+        Seq.empty,
+      $id: String = UUID.randomUUID().toString,
+      $key: String = "no-headers",
+      $timestamp: Long = 1L)
+      extends FlinkEvent
+      with EmbeddedAvroRecord[A]
+      with AssignKafkaHeaders[A]
+
+  property("works with any standard headers") {
+    val rec: RecordWithHeaders = RecordWithHeaders("some string", 17)
+    val event                  = MyEventWithHeaderFields[RecordWithHeaders](
+      rec,
+      Map(
+        "Kafka.Offset" -> "123",
+        "Kafka.Topic"  -> "blah"
+      )
+    )
+    // println(s"$rec")
+    rec.kafka_offset shouldEqual Some(123L)
+    rec.kafka_topic shouldEqual Some("blah")
+    rec.kafka_partition shouldEqual None
+  }
+
+  property("works with no headers") {
+    val rec: RecordWithHeaders = RecordWithHeaders("some string", 17)
+    val event                  = MyEventWithHeaderFields[RecordWithHeaders](
+      rec
+    )
+    // println(s"$rec")
+    rec.kafka_offset shouldEqual None
+    rec.kafka_topic shouldEqual None
+    rec.kafka_partition shouldEqual None
+  }
+
+  property("works with custom headers") {
+    val rec: RecordWithHeaders = RecordWithHeaders("some string", 17)
+    val event                  = MyEventWithHeaderFields[RecordWithHeaders](
+      rec,
+      Map(
+        "someIntHeader" -> "36"
+      ),
+      Seq(
+        KafkaHeaderMapper(
+          "someIntHeader",
+          "myIntHeader",
+          (s: String) => Option(s).map(_.toInt)
+        )
+      )
+    )
+//    println(s"$rec")
+    rec.myIntHeader shouldEqual Some(36)
+  }
+
+}


### PR DESCRIPTION
This small PR adds a trait called `AssignKafkaHeaders[A <: GenericRecord]` that can be used to automatically assign the values in an `EmbeddedAvroRecord[A]`'s `$recordHeaders` map into the embedded avro record itself. The normal `$recordHeaders` map contains a set of 7 standard values, found in `KafkaInfoHeaders`. This includes the topic, partition, offset, serialized key and value lengths, timestamp and timestamp type. To capture these standard values in your embedded avro record, the embedded record schema must contain fields of the appropriate name and type (e.g., a field named `kafka_offset` of type `["null","long"]` with default `null` can hold the `Kafka.Offset` header value). Any missing fields are ignored.

You must extend your event with `AssignKafkaHeaders[A]`. To capture custom kafka headers coming from the consumer record being deserialized you must override `customAssignableHeaders` with a `Seq[KafkaHeaderMapper]` in your event. 

Also, for any of this to work, your `EmbeddedAvroRecordFactory` `fromKV` method must use the headers provided in the `EmbeddedAvroInfo` passed to it to initialize your embedded avro record's $recordHeaders field.